### PR TITLE
internal: Adding CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gleanwork/gleanwork-reviewers


### PR DESCRIPTION
This pull request includes a small change to the `CODEOWNERS` file. The change adds a new team, `@gleanwork/gleanwork-reviewers`, as code owners for all files.