### PR TITLE
internal: Adding publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write    # Needed for creating GitHub releases
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0   # Needed for changelog generation
+    
+    - name: Set up mise
+      uses: jdx/mise-action@v2
+      with:
+        cache: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Build package
+      run: uv build
+
+    - name: Get Tag and Changelog
+      id: CHANGELOG
+      run: |
+        # Get latest tag for both push and manual triggers
+        LATEST_TAG=$(git describe --tags --abbrev=0)
+        
+        echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_OUTPUT
+        echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+        
+        # Try to get previous tag
+        if PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null); then
+          # If we have a previous tag, show changes between tags
+          uvx --from commitizen cz changelog "${PREVIOUS_TAG}..${LATEST_TAG}" --dry-run >> $GITHUB_OUTPUT
+        else
+          # For first tag, show all changes up to this tag
+          uvx --from commitizen cz changelog --dry-run >> $GITHUB_OUTPUT
+        fi
+        echo "EOF" >> $GITHUB_OUTPUT
+      
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.CHANGELOG.outputs.LATEST_TAG }}
+        body: ${{ steps.CHANGELOG.outputs.CHANGELOG }}
+        
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the publication of Python packages to PyPI. The workflow is triggered on new version tags or manually, and it handles building the package, generating a changelog, creating a GitHub release, and publishing the package to PyPI.

### New GitHub Actions Workflow:

* **Workflow Name and Triggers**: Added a new workflow named `Publish to PyPI`, which is triggered by pushes to version tags (`v*.*.*`) or manually via `workflow_dispatch`. (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlR1-R58](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R58))
* **Deployment Steps**:
  - **Checkout Repository**: Uses the `actions/checkout@v4` action with `fetch-depth: 0` to ensure all history is available for changelog generation.
  - **Set Up Mise**: Configures the `jdx/mise-action@v2` action with caching enabled and the required `GITHUB_TOKEN`.
  - **Build Package**: Runs the `uv build` command to build the Python package.
  - **Generate Changelog**: Uses Git commands and `commitizen` to determine the latest and previous tags, then generates a changelog between those tags or for the entire history if it's the first tag.
  - **Create GitHub