### PR TITLE
fix(adapters): correct install hints to use glean-agent-toolkit extras

### DIFF
--- a/src/glean/agent_toolkit/adapters/adk.py
+++ b/src/glean/agent_toolkit/adapters/adk.py
@@ -61,7 +61,7 @@ class ADKAdapter(BaseAdapter["AdkFunctionTool"]):
         if not HAS_ADK:
             raise ImportError(
                 "Google Agent Development Kit (ADK) is required for ADK adapter. "
-                "Install it with `pip install agent_toolkit[adk]` or `pip install google-adk`."
+                "Install it with `pip install glean-agent-toolkit[adk]` or `pip install google-adk`."
             )
 
     def to_tool(self) -> "AdkFunctionTool":

--- a/src/glean/agent_toolkit/adapters/crewai.py
+++ b/src/glean/agent_toolkit/adapters/crewai.py
@@ -124,7 +124,7 @@ class CrewAIAdapter(BaseAdapter[CrewAIToolType]):
         if not HAS_CREWAI:
             raise ImportError(
                 "CrewAI package is required for CrewAI adapter. "
-                "Install it with `pip install agent_toolkit[crewai]`. "
+                "Install it with `pip install glean-agent-toolkit[crewai]`. "
                 "Note: CrewAI requires Python 3.10 or higher."
             )
 

--- a/src/glean/agent_toolkit/adapters/langchain.py
+++ b/src/glean/agent_toolkit/adapters/langchain.py
@@ -78,7 +78,7 @@ class LangChainAdapter(BaseAdapter[LangChainToolType]):
         if not HAS_LANGCHAIN:
             raise ImportError(
                 "LangChain package is required for LangChain adapter. "
-                "Install it with `pip install agent_toolkit[langchain]`."
+                "Install it with `pip install glean-agent-toolkit[langchain]`."
             )
 
     def to_tool(self) -> Any:

--- a/src/glean/agent_toolkit/adapters/openai.py
+++ b/src/glean/agent_toolkit/adapters/openai.py
@@ -72,7 +72,7 @@ class OpenAIAdapter(BaseAdapter[OpenAIToolType]):
         if not HAS_OPENAI:
             raise ImportError(
                 "OpenAI package is required for OpenAI adapter. "
-                "Install it with `pip install agent_toolkit[openai]`."
+                "Install it with `pip install glean-agent-toolkit[openai]`."
             )
 
     def to_tool(self) -> Any:


### PR DESCRIPTION
Update adapter ImportError messages to reference the correct package name for extras:
```
glean-agent-toolkit[openai]
glean-agent-toolkit[langchain]
glean-agent-toolkit[crewai]
glean-agent-toolkit[adk] (keep google-adk as an alternative)
```
Ensures users follow the correct installation instructions.