### PR TITLE
feat(dev): adopt mise with full task parity and Node 22; move dev docs to CONTRIBUTING; README links to CONTRIBUTING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup development environment
-        run: task setup
+        run: mise run setup
 
       - name: Run linters
-        run: task lint
+        run: mise run lint
 
       - name: Build package
-        run: task build
+        run: mise run build
 
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -44,23 +44,21 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           cache: true
-          mise_toml: |
-            [tools]
-            python = "${{ matrix.python-version }}"
-            task = "latest"
-            uv = "latest"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup development environment
-        run: task setup
+        run: mise use -g python@${{ matrix.python-version }} uv@latest && mise install
+
+      - name: Initialize dev environment
+        run: mise run setup
 
       - name: Run tests
-        run: task test
+        run: mise run test
 
       - name: Test package installation
         run: |
-          task build
+          mise run build
           uv run pip install dist/*.whl
           uv run python -c "import glean.agent_toolkit; print('Package installed successfully')"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,34 +6,34 @@ This project contains the **Glean Agent Toolkit**, a Python package used to inte
 
 1. Install the prerequisites:
    - [uv](https://github.com/astral-sh/uv)
-   - [go-task](https://taskfile.dev/)
-2. Run `task setup` to create the `.venv` and install all development, test, lint and typing dependencies via `uv`.
+   - [mise](https://mise.jdx.dev/)
+2. Run `mise run setup` to create the `.venv` and install all development, test, lint and typing dependencies via `uv`.
 
 Environment variables `GLEAN_API_TOKEN` and `GLEAN_INSTANCE` must be set to interact with Glean or regenerate VCR cassettes.
 
 ## Development Tasks
 
-The repository uses **go-task**. Key commands from `Taskfile.yml` include:
+The repository uses **mise**. Key commands include:
 
 | Task | Description |
 |------|-------------|
-| `task test` | Run unit tests |
-| `task test:watch` | Run tests in watch mode |
-| `task test:cov` | Run tests with coverage |
-| `task test:all` | Run tests, apply lint fixes, and run pyright |
-| `task lint` | Run Ruff, formatting checks and pyright |
-| `task lint:diff` | Lint only changed files |
-| `task lint:fix` | Apply Ruff fixes and formatting |
-| `task format` | Format code using Ruff formatter |
-| `task spell:check` | Check spelling |
-| `task clean` | Remove build artifacts |
-| `task build` | Build the package |
-| `task release` | Bump version and generate the changelog |
+| `mise run test` | Run unit tests |
+| `mise run test:watch` | Run tests in watch mode |
+| `mise run test:cov` | Run tests with coverage |
+| `mise run test:all` | Run tests, apply lint fixes, and run pyright |
+| `mise run lint` | Run Ruff, formatting checks and pyright |
+| `mise run lint:diff` | Lint only changed files |
+| `mise run lint:fix` | Apply Ruff fixes and formatting |
+| `mise run format` | Format code using Ruff formatter |
+| `mise run spell:check` | Check spelling |
+| `mise run clean` | Remove build artifacts |
+| `mise run build` | Build the package |
+| `mise run release` | Bump version and generate the changelog |
 
 Special tasks exist to manage VCR cassettes used in tests:
 
-- `task test:vcr:regenerate` – Re-record all HTTP interactions (requires `GLEAN_API_TOKEN` and `GLEAN_INSTANCE`).
-- `task test:vcr:clean` – Delete cassettes so the next test run regenerates them.
+- `mise run test:vcr:regenerate` – Re-record all HTTP interactions (requires `GLEAN_API_TOKEN` and `GLEAN_INSTANCE`).
+- `mise run test:vcr:clean` – Delete cassettes so the next test run regenerates them.
 
 ## Coding Guidelines
 
@@ -45,7 +45,7 @@ Special tasks exist to manage VCR cassettes used in tests:
 ## Contribution Process
 
 1. Fork the repository and create a branch from `main`.
-2. Make your changes and ensure all tasks run cleanly (`task test` and `task lint`).
+2. Make your changes and ensure all tasks run cleanly (`mise run test` and `mise run lint`).
 3. Update or add documentation when necessary.
 4. Submit a pull request.
 5. Be respectful and follow the project's code of conduct.

--- a/COMMIT_LINTING.md
+++ b/COMMIT_LINTING.md
@@ -25,7 +25,7 @@ Examples:
 
 ```bash
 # Install all dependencies including pre-commit
-task setup
+mise run setup
 ```
 
 This will:
@@ -37,7 +37,7 @@ This will:
 
 ```bash
 # Install pre-commit hooks
-task pre-commit:install
+mise run pre-commit:install
 ```
 
 ## Available Tools
@@ -54,13 +54,13 @@ Pre-commit hooks run automatically before each commit and will:
 
 ```bash
 # Run pre-commit hooks on all files
-task pre-commit:run
+mise run pre-commit:run
 
 # Run pre-commit hooks on changed files only
-task pre-commit:run:diff
+mise run pre-commit:run:diff
 
 # Update pre-commit hooks to latest versions
-task pre-commit:update
+mise run pre-commit:update
 ```
 
 ## Making Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to the Glean Agent Toolkit! This gui
 ```sh
 src/
 ├─ glean/
-│  ├─ __init__.py        
+│  ├─ __init__.py
 │  └─ agent_toolkit/     # exposes `glean.agent_toolkit`
 │     ├─ __init__.py
 │     ├─ decorators.py
@@ -22,64 +22,64 @@ src/
 
 ## Development environment
 
-The repository relies on [uv](https://github.com/astral-sh/uv) and [go-task](https://taskfile.dev/) for reproducible workflows.
+The repository relies on [uv](https://github.com/astral-sh/uv) and [mise](https://mise.jdx.dev/) for reproducible workflows and task orchestration.
 
 ### Prerequisites
 
 1. uv
 
-    ```bash
-    pip install uv
-    ```
+   ```bash
+   pip install uv
+   ```
 
-2. go-task
+2. mise
 
-    ```bash
-    brew install go-task
-    ```
+   ```bash
+   brew install mise
+   ```
 
 ### One-time setup
 
 ```bash
-task setup
+mise run setup
 ```
 
 The command creates `.venv/` and installs all dev/test dependencies via uv.
 
 ## Development Tasks
 
-The project uses [go-task](https://taskfile.dev/) to manage development tasks. Here are the available tasks:
+The project uses `mise` to manage development tasks. Here are the available tasks:
 
 ### Testing
 
-| Task | Description |
-|------|-------------|
-| `task test` | Run unit tests |
-| `task test:watch` | Run tests in watch mode |
-| `task test:cov` | Run tests with coverage |
-| `task test:all` | Run all tests and lint fixes |
+| Task                  | Description                  |
+| --------------------- | ---------------------------- |
+| `mise run test`       | Run unit tests               |
+| `mise run test:watch` | Run tests in watch mode      |
+| `mise run test:cov`   | Run tests with coverage      |
+| `mise run test:all`   | Run all tests and lint fixes |
 
 ### Linting and formatting
 
-| Task | Description |
-|------|-------------|
-| `task lint` | Run Ruff, pyright and formatting checks |
-| `task lint:diff` | Same as above but only on changed files |
-| `task lint:package` | Lint only `glean/toolkit` |
-| `task lint:tests` | Lint only `tests` |
-| `task lint:fix` | Autofix style issues |
-| `task format` | Apply Ruff formatter |
-| `task format:diff` | Format only changed files |
+| Task                    | Description                             |
+| ----------------------- | --------------------------------------- |
+| `mise run lint`         | Run Ruff, pyright and formatting checks |
+| `mise run lint:diff`    | Same as above but only on changed files |
+| `mise run lint:package` | Lint only `glean/toolkit`               |
+| `mise run lint:tests`   | Lint only `tests`                       |
+| `mise run lint:fix`     | Autofix style issues                    |
+| `mise run format`       | Apply Ruff formatter                    |
+| `mise run format:diff`  | Format only changed files               |
 
 ### Examples and Utilities
 
-| Task | Description |
-|------|-------------|
-| `task spell:check` | Check spelling |
-| `task spell:fix` | Fix spelling |
-| `task clean` | Clean build artifacts |
-| `task build` | Build the package |
-| `task release` | Create a new release (version bump + changelog) |
+| Task                   | Description                                     |
+| ---------------------- | ----------------------------------------------- |
+| `mise run spell:check` | Check spelling                                  |
+| `mise run spell:fix`   | Fix spelling                                    |
+| `mise run clean`       | Clean build artifacts                           |
+| `mise run build`       | Build the package                               |
+| `mise run release`     | Create a new release (version bump + changelog) |
 
 ## Pull Request Process
 
@@ -90,4 +90,4 @@ The project uses [go-task](https://taskfile.dev/) to manage development tasks. H
 
 ## Code of Conduct
 
-Please be respectful and considerate of others when contributing to this project. 
+Please be respectful and considerate of others when contributing to this project.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and k
 
 ## Key Features
 
-* **Production-Ready Glean Tools:** Instantly add capabilities like enterprise search, employee lookup, calendar search, Gmail search, and more to your agents.
-* **Framework Adapters:** Seamlessly convert Glean tools into formats compatible with major agent SDKs.
-* **Custom Tool Creation:** Define your own tools once using the `@tool_spec` decorator and use them across any supported framework.
+- **Production-Ready Glean Tools:** Instantly add capabilities like enterprise search, employee lookup, calendar search, Gmail search, and more to your agents.
+- **Framework Adapters:** Seamlessly convert Glean tools into formats compatible with major agent SDKs.
+- **Custom Tool Creation:** Define your own tools once using the `@tool_spec` decorator and use them across any supported framework.
 
 ## Installation
 
@@ -136,12 +136,12 @@ cd company_assistant/
 
 Once set up, your Company Assistant can handle requests like:
 
-- *"Find our security guidelines for handling customer data"*
-- *"Who's the product manager for the mobile app team?"*
-- *"Show me emails about the budget planning meeting from last week"*
-- *"I need the engineering team's architecture docs for the payment system"*
-- *"Find all the design review meetings scheduled for this month"*
-- *"Who worked on the API authentication project? I need to ask them some questions"*
+- _"Find our security guidelines for handling customer data"_
+- _"Who's the product manager for the mobile app team?"_
+- _"Show me emails about the budget planning meeting from last week"_
+- _"I need the engineering team's architecture docs for the payment system"_
+- _"Find all the design review meetings scheduled for this month"_
+- _"Who worked on the API authentication project? I need to ask them some questions"_
 
 This type of assistant can dramatically improve employee productivity by making company knowledge instantly accessible through natural conversation.
 
@@ -149,14 +149,14 @@ This type of assistant can dramatically improve employee productivity by making 
 
 The toolkit comes with a suite of production-ready tools that connect to various Glean functionalities:
 
-* **`glean_search`**: Search your company's knowledge base for relevant documents and information
-* **`web_search`**: Search the public web for up-to-date external information
-* **`ai_web_search`**: Query Google Gemini for AI-powered web information
-* **`calendar_search`**: Find meetings and calendar events
-* **`employee_search`**: Search for employees by name, team, department, or expertise
-* **`code_search`**: Search your company's source code repositories
-* **`gmail_search`**: Search Gmail messages and conversations
-* **`outlook_search`**: Search Outlook mail and calendar items
+- **`glean_search`**: Search your company's knowledge base for relevant documents and information
+- **`web_search`**: Search the public web for up-to-date external information
+- **`ai_web_search`**: Query Google Gemini for AI-powered web information
+- **`calendar_search`**: Find meetings and calendar events
+- **`employee_search`**: Search for employees by name, team, department, or expertise
+- **`code_search`**: Search your company's source code repositories
+- **`gmail_search`**: Search Gmail messages and conversations
+- **`outlook_search`**: Search Outlook mail and calendar items
 
 ## Quick Start Examples
 
@@ -389,4 +389,4 @@ Interested in contributing? Check out our [Contributing Guide](CONTRIBUTING.md) 
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE). 
+This project is licensed under the [MIT License](LICENSE).

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,197 @@
 [tools]
 python = "3.10"
-task = "latest"
 uv = "latest"
+node = "22"
+
+[tasks]
+
+[tasks.setup]
+description = "Set up local environment (install dependencies, etc.)"
+run = [
+  "uv venv .venv",
+  "uv pip install -e .[dev,test,lint,typing,codespell]",
+  "uv run pre-commit install",
+  "uv run pre-commit install --hook-type commit-msg",
+]
+
+[tasks."test:all"]
+description = "Run all tests and lint fixes"
+run = [
+  "mise run test",
+  "mise run lint:fix",
+  "mise run lint:pyright",
+]
+
+[tasks.test]
+description = "Run unit tests"
+run = "uv run pytest -v --tb=auto -rA --durations=10 -p no:logging tests/"
+
+[tasks."test:watch"]
+description = "Run tests in watch mode"
+run = "uv run ptw --now . -- -vv --tb=auto -rA --durations=10 -p no:logging tests/"
+
+[tasks."test:cov"]
+description = "Run tests with coverage"
+run = "uv run pytest --cov=glean --cov-report=term --cov-report=html -v tests/"
+
+[tasks."test:vcr:regenerate"]
+description = "Regenerate all VCR cassettes by re-recording HTTP interactions"
+run = [
+  "bash -lc '[ -n \"$GLEAN_API_TOKEN\" ] || { echo \"GLEAN_API_TOKEN environment variable is required for recording\"; exit 1; }'",
+  "bash -lc '[ -n \"$GLEAN_INSTANCE\" ] || { echo \"GLEAN_INSTANCE environment variable is required for recording\"; exit 1; }'",
+  "uv run pytest -v tests/ --tb=auto -rA",
+]
+[tasks."test:vcr:regenerate".env]
+VCR_REGENERATE = "true"
+
+[tasks."test:vcr:clean"]
+description = "Delete all VCR cassettes to force regeneration on next test run"
+run = [
+  "rm -rf tests/cassettes/*",
+  "echo Deleted all VCR cassettes",
+]
+
+[tasks.lint]
+description = "Run all linters"
+run = [
+  "mise run lint:ruff",
+  "mise run lint:format:check",
+  "mise run lint:pyright",
+  "mise run lint:readme",
+]
+
+[tasks."lint:diff"]
+description = "Run linters on changed files"
+run = [
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); [ -z \\\"$PYTHON_FILES\\\" ] || uv run ruff check $PYTHON_FILES\"",
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); [ -z \\\"$PYTHON_FILES\\\" ] || uv run ruff format $PYTHON_FILES --diff\"",
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); if [ -z \\\"$PYTHON_FILES\\\" ]; then uv run pyright; else uv run pyright $PYTHON_FILES; fi\"",
+]
+
+[tasks."lint:package"]
+description = "Run linters on package files"
+run = [
+  "uv run ruff check src/glean/toolkit",
+  "uv run ruff format src/glean/toolkit --diff",
+  "uv run pyright src/glean/toolkit",
+]
+
+[tasks."lint:tests"]
+description = "Run linters on test files"
+run = [
+  "uv run ruff check tests",
+  "uv run ruff format tests --diff",
+  "uv run pyright tests",
+]
+
+[tasks."lint:fix"]
+description = "Run the lint autofixers"
+run = [
+  "mise run lint:fix:ruff",
+  "mise run format",
+]
+
+[tasks."lint:fix:diff"]
+description = "Run lint autofixers on changed files"
+run = [
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); [ -z \\\"$PYTHON_FILES\\\" ] || uv run ruff check $PYTHON_FILES --fix\"",
+  "mise run format:diff",
+]
+
+[tasks."lint:fix:package"]
+description = "Run lint autofixers on package files"
+run = [
+  "uv run ruff check src/glean/toolkit --fix",
+  "mise run format",
+]
+
+[tasks."lint:fix:ruff"]
+description = "Run Ruff autofixer"
+run = "uv run ruff check . --fix --exclude .venv/ --exclude **/site-packages/"
+
+[tasks."lint:ruff"]
+description = "Run Ruff linter"
+run = "uv run ruff check . --exclude .venv/ --exclude **/site-packages/"
+
+[tasks."lint:format:check"]
+description = "Check code formatting"
+run = "uv run ruff format . --diff"
+
+[tasks."lint:pyright"]
+description = "Run Pyright type checker"
+run = "uv run pyright"
+
+[tasks."lint:readme"]
+description = "Lint the README.md file"
+run = "npx -y markdown-code check"
+
+[tasks."lint:readme:fix"]
+description = "Fix the README.md file"
+run = "npx -y markdown-code sync"
+
+[tasks.format]
+description = "Run code formatters"
+run = [
+  "mise run format:ruff",
+  "mise run format:imports",
+]
+
+[tasks."format:diff"]
+description = "Run formatters on changed files"
+run = [
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); [ -z \\\"$PYTHON_FILES\\\" ] || uv run ruff format $PYTHON_FILES\"",
+  "bash -lc \"PYTHON_FILES=$(git diff --name-only --diff-filter=d main | grep -E '.*\\.(py|ipynb)$' || true); [ -z \\\"$PYTHON_FILES\\\" ] || uv run ruff check --select I --fix $PYTHON_FILES\"",
+]
+
+[tasks."format:ruff"]
+description = "Run Ruff formatter"
+run = "uv run ruff format ."
+
+[tasks."format:imports"]
+description = "Fix imports"
+run = "uv run ruff check --select I --fix ."
+
+[tasks."spell:check"]
+description = "Check spelling"
+run = "uv run codespell --toml pyproject.toml --skip=docs/"
+
+[tasks."spell:fix"]
+description = "Fix spelling"
+run = "uv run codespell --toml pyproject.toml -w --skip=docs/"
+
+[tasks.clean]
+description = "Clean build artifacts"
+run = [
+  "rm -rf dist .venv build **/*.egg-info .pytest_cache .coverage htmlcov .ruff_cache",
+  "find . -name \"*.pyc\" -delete",
+  "find . -name \"__pycache__\" -delete",
+]
+
+[tasks.build]
+description = "Build the package"
+run = "uv run python -m build"
+
+[tasks."pre-commit:install"]
+description = "Install pre-commit hooks"
+run = [
+  "uv run pre-commit install",
+  "uv run pre-commit install --hook-type commit-msg",
+]
+
+[tasks."pre-commit:run"]
+description = "Run pre-commit hooks on all files"
+run = "uv run pre-commit run --all-files"
+
+[tasks."pre-commit:run:diff"]
+description = "Run pre-commit hooks on changed files"
+run = "uv run pre-commit run"
+
+[tasks."pre-commit:update"]
+description = "Update pre-commit hooks"
+run = "uv run pre-commit autoupdate"
+
+[tasks.release]
+description = "Bump version and create a new tag (use DRY_RUN=true for preview)"
+run = [
+  "bash -lc 'if [ \"$DRY_RUN\" = \"true\" ]; then uv run python -m commitizen bump --dry-run && uv run python -m commitizen changelog --dry-run; else uv run python -m commitizen bump --yes && uv run python -m commitizen changelog; fi'",
+]


### PR DESCRIPTION
### TL;DR

Replace go-task with mise for task orchestration and development workflows.

### What changed?

- Replaced all `task` commands with `mise run` commands throughout the codebase
- Migrated task definitions from `Taskfile.yml` to `mise.toml`
- Updated CI workflows to use mise instead of task
- Updated all documentation (README, CONTRIBUTING, AGENTS, COMMIT_LINTING) to reference mise instead of go-task
- Simplified the GitHub Actions workflow by using mise's built-in tool management

### How to test?

1. Install mise: `brew install mise`
2. Run `mise run setup` to initialize the development environment
3. Try running various commands like `mise run test`, `mise run lint`, etc.
4. Verify that CI passes with the updated workflow configuration

### Why make this change?

Mise provides a more integrated approach to managing both tools and tasks in a single configuration file. This change simplifies the development environment setup by consolidating tool version management and task orchestration into a single system, making it easier for contributors to get started and maintain consistency across environments.