### PR TITLE
docs: add instance prerequisites per tool; link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Before using any Glean tools, you'll need:
    export GLEAN_INSTANCE="your-instance-name"
    ```
 
+See `docs/prerequisites.md` for instance-level connector and Admin settings required per tool.
+
 ## Quickstart Example: Company Assistant with Google ADK
 
 Here's a complete example that demonstrates the power of the Glean Agent Toolkit. We'll build a "Company Assistant" using Google's Agent Development Kit (ADK) that can help employees find information, discover colleagues, and search company resources.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,6 +1,6 @@
-# Glean Agent Toolkit: Instance Prerequisites
+# Glean Agent Toolkit: Glean Instance Prerequisites
 
-This guide summarizes instance-level requirements to use the built-in tools. Ensure your Glean Admin has enabled the relevant features and connectors for your tenant.
+This guide summarizes requirements for your organization's Glean instance (tenant) to use the built-in tools. Ensure your Glean Admin has enabled the relevant features and connectors for your tenant.
 
 ## Global requirements
 
@@ -8,8 +8,8 @@ This guide summarizes instance-level requirements to use the built-in tools. Ens
   - `GLEAN_API_TOKEN`
   - `GLEAN_INSTANCE`
 
-- Instance access
-  - Tools API enabled for your tenant
+- Glean instance access
+  - Tools API enabled
   - Users have access to underlying content/apps (authorization enforced by Glean)
 
 ## Tool-specific requirements

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,6 +1,6 @@
 # Glean Agent Toolkit: Glean Instance Prerequisites
 
-This guide summarizes requirements for your organization's Glean instance (tenant) to use the built-in tools. Ensure your Glean Admin has enabled the relevant features and connectors for your tenant.
+This guide summarizes requirements for your organization's Glean instance to use the built-in tools. Ensure your Glean Admin has enabled the relevant features and connectors.
 
 ## Global requirements
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -18,37 +18,31 @@ This guide summarizes requirements for your organization's Glean instance to use
 
 - Connectors: Any content sources your organization has connected to Glean
 - Admin toggles: Client API enabled
-- Permissions: Users must have view access to content surfaced
 
 ### `employee_search`
 
 - Connectors: Directory/HR sources (e.g., Google Workspace Directory, Azure AD, HRIS if applicable)
 - Admin toggles: People/Directory data available to Client API
-- Permissions: Users can view directory profiles per org policy
 
 ### `calendar_search`
 
 - Connectors: Google Calendar and/or Microsoft 365 Calendar
 - Admin toggles: Calendar search enabled for Client API
-- Permissions: Users can view event metadata per calendar sharing rules; transcripts require recording/ingestion being enabled where applicable
 
 ### `gmail_search`
 
 - Connectors: Google Workspace Gmail
 - Admin toggles: Gmail search enabled for Client API
-- Permissions: Users can search only their mailbox per Gmail/Glean policies
 
 ### `outlook_search`
 
 - Connectors: Microsoft 365 (Outlook Mail)
 - Admin toggles: Outlook search enabled for Client API
-- Permissions: Users can search only their mailbox per M365/Glean policies
 
 ### `code_search`
 
 - Connectors: One or more code hosts (GitHub, GitLab, Bitbucket, Azure Repos)
 - Admin toggles: Code Search enabled for your organization's Glean instance and available to Client API
-- Permissions: Users must have read access to repositories/organizations
 
 ## Verification checklist
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -17,13 +17,13 @@ This guide summarizes requirements for your organization's Glean instance to use
 ### `glean_search`
 
 - Connectors: Any content sources your organization has connected to Glean
-- Admin toggles: Search and Client API enabled
+- Admin toggles: Client API enabled
 - Permissions: Users must have view access to content surfaced
 
 ### `employee_search`
 
 - Connectors: Directory/HR sources (e.g., Google Workspace Directory, Azure AD, HRIS if applicable)
-- Admin toggles: People/Directory data available to Search and Client API
+- Admin toggles: People/Directory data available to Client API
 - Permissions: Users can view directory profiles per org policy
 
 ### `calendar_search`

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,63 @@
+# Glean Agent Toolkit: Instance Prerequisites
+
+This guide summarizes instance-level requirements to use the built-in tools. Ensure your Glean Admin has enabled the relevant features and connectors for your tenant.
+
+## Global requirements
+
+- Environment variables
+  - `GLEAN_API_TOKEN`
+  - `GLEAN_INSTANCE`
+
+- Instance access
+  - Tools API enabled for your tenant
+  - Users have access to underlying content/apps (authorization enforced by Glean)
+
+## Tool-specific requirements
+
+### `glean_search`
+
+- Connectors: Google Workspace and/or Microsoft 365 content sources (Docs/Drive, SharePoint/OneDrive, etc.) as applicable
+- Admin toggles: Search/Tools API enabled
+- Permissions: Users must have view access to content surfaced
+
+### `employee_search`
+
+- Connectors: Directory/HR sources (e.g., Google Workspace Directory, Azure AD, HRIS if applicable)
+- Admin toggles: People/Directory data available to Search/Tools
+- Permissions: Users can view directory profiles per org policy
+
+### `calendar_search`
+
+- Connectors: Google Calendar and/or Microsoft 365 Calendar
+- Admin toggles: Calendar search enabled for Tools API
+- Permissions: Users can view event metadata per calendar sharing rules; transcripts require recording/ingestion being enabled where applicable
+
+### `gmail_search`
+
+- Connectors: Google Workspace Gmail
+- Admin toggles: Gmail search enabled for Tools API
+- Permissions: Users can search only their mailbox per Gmail/Glean policies
+
+### `outlook_search`
+
+- Connectors: Microsoft 365 (Outlook Mail)
+- Admin toggles: Outlook search enabled for Tools API
+- Permissions: Users can search only their mailbox per M365/Glean policies
+
+### `code_search`
+
+- Connectors: One or more code hosts (GitHub, GitLab, Bitbucket, Azure Repos)
+- Admin toggles: Code Search enabled for your tenant and available to Tools API
+- Permissions: Users must have read access to repositories/organizations
+
+## Verification checklist
+
+- Confirm Tools API access with a simple `glean_search` call
+- Verify each connector is authorized and indexed in Admin
+- Test per-user scoping by running a tool with a least-privilege account
+
+## Troubleshooting
+
+- 401/403 errors: validate `GLEAN_API_TOKEN`, `GLEAN_INSTANCE`, and user permissions
+- Empty results: confirm connector indexing status and that the feature is enabled for Tools
+- Code search gaps: ensure all relevant orgs/repos are connected and indexing completed

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -16,7 +16,7 @@ This guide summarizes requirements for your organization's Glean instance to use
 
 ### `glean_search`
 
-- Connectors: Google Workspace and/or Microsoft 365 content sources (Docs/Drive, SharePoint/OneDrive, etc.) as applicable
+- Connectors: Any content sources your organization has connected to Glean
 - Admin toggles: Search/Tools API enabled
 - Permissions: Users must have view access to content surfaced
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -9,7 +9,7 @@ This guide summarizes requirements for your organization's Glean instance to use
   - `GLEAN_INSTANCE`
 
 - Glean instance access
-  - Tools API enabled
+  - Client API and Tools enabled
   - Users have access to underlying content/apps (authorization enforced by Glean)
 
 ## Tool-specific requirements
@@ -17,47 +17,47 @@ This guide summarizes requirements for your organization's Glean instance to use
 ### `glean_search`
 
 - Connectors: Any content sources your organization has connected to Glean
-- Admin toggles: Search/Tools API enabled
+- Admin toggles: Search and Client API enabled
 - Permissions: Users must have view access to content surfaced
 
 ### `employee_search`
 
 - Connectors: Directory/HR sources (e.g., Google Workspace Directory, Azure AD, HRIS if applicable)
-- Admin toggles: People/Directory data available to Search/Tools
+- Admin toggles: People/Directory data available to Search and Client API
 - Permissions: Users can view directory profiles per org policy
 
 ### `calendar_search`
 
 - Connectors: Google Calendar and/or Microsoft 365 Calendar
-- Admin toggles: Calendar search enabled for Tools API
+- Admin toggles: Calendar search enabled for Client API
 - Permissions: Users can view event metadata per calendar sharing rules; transcripts require recording/ingestion being enabled where applicable
 
 ### `gmail_search`
 
 - Connectors: Google Workspace Gmail
-- Admin toggles: Gmail search enabled for Tools API
+- Admin toggles: Gmail search enabled for Client API
 - Permissions: Users can search only their mailbox per Gmail/Glean policies
 
 ### `outlook_search`
 
 - Connectors: Microsoft 365 (Outlook Mail)
-- Admin toggles: Outlook search enabled for Tools API
+- Admin toggles: Outlook search enabled for Client API
 - Permissions: Users can search only their mailbox per M365/Glean policies
 
 ### `code_search`
 
 - Connectors: One or more code hosts (GitHub, GitLab, Bitbucket, Azure Repos)
-- Admin toggles: Code Search enabled for your tenant and available to Tools API
+- Admin toggles: Code Search enabled for your organization's Glean instance and available to Client API
 - Permissions: Users must have read access to repositories/organizations
 
 ## Verification checklist
 
-- Confirm Tools API access with a simple `glean_search` call
+- Confirm Client API access with a simple `glean_search` call
 - Verify each connector is authorized and indexed in Admin
 - Test per-user scoping by running a tool with a least-privilege account
 
 ## Troubleshooting
 
 - 401/403 errors: validate `GLEAN_API_TOKEN`, `GLEAN_INSTANCE`, and user permissions
-- Empty results: confirm connector indexing status and that the feature is enabled for Tools
+- Empty results: confirm connector indexing status and that the feature is enabled for Client API
 - Code search gaps: ensure all relevant orgs/repos are connected and indexing completed


### PR DESCRIPTION
# Add Glean Instance Prerequisites Documentation

### TL;DR

Added detailed documentation about the Glean instance prerequisites required for each tool in the Agent Toolkit.

### What changed?

- Created a new `docs/prerequisites.md` file with comprehensive information about:
  - Global requirements for all tools
  - Tool-specific requirements for each component (`glean_search`, `employee_search`, `calendar_search`, etc.)
  - Verification checklist for administrators
  - Troubleshooting guidance for common issues
- Updated the README.md to reference the new prerequisites documentation

### How to test?

1. Review the new `docs/prerequisites.md` file to ensure it accurately describes requirements
2. Verify the link in README.md correctly points to the new documentation
3. Test that the information helps users properly configure their Glean instance

### Why make this change?

Users need clear guidance on how to configure their Glean instance before using the Agent Toolkit. This documentation helps administrators understand which connectors and settings are required for each tool, reducing setup issues and improving the onboarding experience.