### PR TITLE
chore(types): set pyright pythonVersion to 3.10 to match runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ packages = ["src/glean"]
 include = ["src", "tests"]
 exclude = ["**/__pycache__", ".venv/"]
 venvPath = "."
-pythonVersion = "3.13"
+pythonVersion = "3.10"
 reportMissingImports = "warning"
 reportUnusedVariable = "warning"
 


### PR DESCRIPTION
### TL;DR

Updated the Python version in pyproject.toml from 3.13 to 3.10 for Pyright type checking.

### What changed?

Changed the `pythonVersion` configuration parameter in pyproject.toml from "3.13" to "3.10" for Pyright static type checking.

### How to test?

1. Run Pyright type checking to ensure it works correctly with Python 3.10
2. Verify that type checking doesn't produce unexpected errors with the new Python version setting

### Why make this change?

This change aligns the Pyright type checking with a more widely used Python version (3.10). Python 3.13 is still in development and not widely adopted, so using 3.10 ensures better compatibility with existing codebases and development environments.