### PR TITLE
hotfix: fix retry config to unbreak main

### DIFF
--- a/src/glean/agent_toolkit/tools/_common.py
+++ b/src/glean/agent_toolkit/tools/_common.py
@@ -71,19 +71,18 @@ def _parse_retry_env_int(name: str, default: int) -> int:
 def _build_retry_config() -> RetryConfig:
     initial = _parse_retry_env_float("GLEAN_RETRY_INITIAL", 1.0)
     maximum = _parse_retry_env_float("GLEAN_RETRY_MAX", 50.0)
-    multiplier = _parse_retry_env_float("GLEAN_RETRY_MULTIPLIER", 1.1)
-    jitter_ms = _parse_retry_env_int("GLEAN_RETRY_JITTER_MS", 100)
-    retry_on_rate_limit = os.getenv("GLEAN_RETRY_ON_RATE_LIMIT", "true").lower() != "false"
+    exponent = _parse_retry_env_float("GLEAN_RETRY_MULTIPLIER", 1.1)
+    max_elapsed = _parse_retry_env_float("GLEAN_RETRY_MAX_ELAPSED", 60.0)
 
     return RetryConfig(
         strategy="backoff",
-        backoff_strategy=BackoffStrategy(
-            initial=initial,
-            maximum=maximum,
-            multiplier=multiplier,
-            jitter=jitter_ms,
+        backoff=BackoffStrategy(
+            initial_interval=initial,
+            max_interval=maximum,
+            exponent=exponent,
+            max_elapsed_time=max_elapsed,
         ),
-        retry_on_rate_limit=retry_on_rate_limit,
+        retry_connection_errors=True,
     )
 
 


### PR DESCRIPTION
Align RetryConfig fields to client (backoff initial_interval/max_interval/exponent/max_elapsed_time; retry_connection_errors). Unblocks Pyright CI.