### PR TITLE
chore: Add read_document tool to fetch full document content

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and k
 
 ### Retry configuration (env vars)
 
-| Variable | Default | Description | Example |
-| --- | --- | --- | --- |
-| `GLEAN_RETRY_INITIAL` | `1.0` | Initial backoff in seconds | `0.5` |
-| `GLEAN_RETRY_MAX` | `50.0` | Maximum backoff in seconds | `8` |
-| `GLEAN_RETRY_MULTIPLIER` | `1.1` | Exponential backoff multiplier | `2.0` |
-| `GLEAN_RETRY_JITTER_MS` | `100` | Random jitter in milliseconds | `250` |
-| `GLEAN_RETRY_ON_RATE_LIMIT` | `true` | Retry on HTTP 429 rate limits | `true` |
+| Variable                    | Default | Description                    | Example |
+| --------------------------- | ------- | ------------------------------ | ------- |
+| `GLEAN_RETRY_INITIAL`       | `1.0`   | Initial backoff in seconds     | `0.5`   |
+| `GLEAN_RETRY_MAX`           | `50.0`  | Maximum backoff in seconds     | `8`     |
+| `GLEAN_RETRY_MULTIPLIER`    | `1.1`   | Exponential backoff multiplier | `2.0`   |
+| `GLEAN_RETRY_JITTER_MS`     | `100`   | Random jitter in milliseconds  | `250`   |
+| `GLEAN_RETRY_ON_RATE_LIMIT` | `true`  | Retry on HTTP 429 rate limits  | `true`  |
 
 Retries cover transient failures such as HTTP 429/5xx and connection timeouts. Set these before constructing any Glean client usage.
 
@@ -178,7 +178,9 @@ This type of assistant can dramatically improve employee productivity by making 
 
 The toolkit comes with a suite of production-ready tools that connect to various Glean functionalities:
 
-- **`glean_search`**: Search your company's knowledge base for relevant documents and information
+- **`search`**: Search your company's knowledge base for relevant documents and information
+- **`read_document`**: Read full content of a specific document by ID or URL (requires
+  config settings `queryapi.getDocuments.enabled` and `queryapi.getDocuments.content.enabled`)
 - **`web_search`**: Search the public web for up-to-date external information
 - **`ai_web_search`**: Query Google Gemini for AI-powered web information
 - **`calendar_search`**: Find meetings and calendar events

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -47,9 +47,16 @@ This guide summarizes requirements for your organization's Glean instance to use
 
 ## Verification checklist
 
-- Confirm Client API access with a simple `glean_search` call
+- Confirm Client API access with a simple `search` call
 - Verify each connector is authorized and indexed in Admin
 - Test per-user scoping by running a tool with a least-privilege account
+
+### `read_document`
+
+- Config settings (must be enabled):
+  - `queryapi.getDocuments.enabled`
+  - `queryapi.getDocuments.content.enabled`
+  - These enable the `documents.read_document` API to return full content
 
 ## Troubleshooting
 

--- a/src/glean/agent_toolkit/tools/__init__.py
+++ b/src/glean/agent_toolkit/tools/__init__.py
@@ -17,6 +17,7 @@ _tool_modules: list[str] = [
     "code_search",
     "gmail_search",
     "outlook_search",
+    "read_document",
 ]
 
 for _mod in _tool_modules:
@@ -28,6 +29,7 @@ from .code_search import code_search  # noqa: E402
 from .employee_search import employee_search  # noqa: E402
 from .gmail_search import gmail_search  # noqa: E402
 from .outlook_search import outlook_search  # noqa: E402
+from .read_document import read_document  # noqa: E402
 from .search import search  # noqa: E402
 from .web_search import web_search  # noqa: E402
 
@@ -40,4 +42,5 @@ __all__: list[str] = [
     "code_search",
     "gmail_search",
     "outlook_search",
+    "read_document",
 ]

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -72,9 +72,8 @@ def read_document(
             include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
 
             if document_id:
-                document_id = document_id  # Use document ID directly without cleaning
                 request = models.GetDocumentsRequest(
-                    document_specs=[models.DocumentSpec2(id=did)],
+                    document_specs=[models.DocumentSpec2(id=document_id)],
                     include_fields=include_fields,
                 )
             else:

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -1,0 +1,90 @@
+"""Read Document tool for fetching full content by document ID or URL."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypedDict
+
+from pydantic import Field
+
+import glean.agent_toolkit.tools._common as common
+from glean.agent_toolkit.decorators import tool_spec
+from glean.api_client import models
+from glean.api_client.client_documents import ClientDocuments
+
+
+class ReadDocumentSuccess(TypedDict):
+    """Successful read document result payload."""
+
+    result: models.GetDocumentsResponse
+
+
+class ReadDocumentError(TypedDict):
+    """Error result payload for read document."""
+
+    error: str
+    result: None
+
+
+@tool_spec(
+    name="read_document",
+    description=(
+        "Read the full content of a specific document by ID or URL.\n"
+        "INSTRUCTIONS:\n"
+        "- Provide exactly one of document_id or url.\n"
+        "- The tool requires instance settings: queryapi.getDocuments.enabled and "
+        "queryapi.getDocuments.content.enabled."
+    ),
+)
+def read_document(
+    document_id: Annotated[
+        str | None,
+        Field(
+            description="Glean document ID (e.g., glean_123456789)",
+            examples=["glean_15349475685754208208"],
+        ),
+    ] = None,
+    url: Annotated[
+        str | None,
+        Field(
+            description="Document URL to resolve and read",
+            examples=[
+                "https://docs.google.com/document/d/REDACTED",
+                "https://company.slack.com/archives/C123/p1234567890",
+            ],
+        ),
+    ] = None,
+) -> ReadDocumentSuccess | ReadDocumentError:
+    """Fetch full document content using the Glean Client API.
+
+    One of document_id or url must be provided. If both or neither are provided,
+    an error will be returned.
+    """
+    if bool(document_id) == bool(url):
+        return {
+            "error": "Provide exactly one of document_id or url",
+            "result": None,
+        }
+
+    try:
+        with common.api_client() as g_client:
+            documents_client: ClientDocuments = g_client.client.documents
+
+            include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
+
+            if document_id:
+                did = common.clean_query(document_id)
+                request = models.GetDocumentsRequest(
+                    document_specs=[models.DocumentSpec2(id=did)],
+                    include_fields=include_fields,
+                )
+            else:
+                request = models.GetDocumentsRequest(
+                    document_specs=[models.DocumentSpec1(url=common.clean_query(url or ""))],
+                    include_fields=include_fields,
+                )
+
+            result = documents_client.retrieve(request=request)
+
+        return {"result": result}
+    except Exception as e:
+        return {"error": str(e), "result": None}

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -72,7 +72,7 @@ def read_document(
             include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
 
             if document_id:
-                did = common.clean_query(document_id)
+                document_id = document_id  # Use document ID directly without cleaning
                 request = models.GetDocumentsRequest(
                     document_specs=[models.DocumentSpec2(id=did)],
                     include_fields=include_fields,

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -59,7 +59,7 @@ def read_document(
     One of document_id or url must be provided. If both or neither are provided,
     an error will be returned.
     """
-    if bool(document_id) == bool(url):
+    if (document_id and url) or (not document_id and not url):
         return {
             "error": "Provide exactly one of document_id or url",
             "result": None,

--- a/tests/tools/test_read_document.py
+++ b/tests/tools/test_read_document.py
@@ -1,0 +1,70 @@
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from glean.agent_toolkit.tools.read_document import read_document
+from glean.api_client import models
+
+
+def test_read_document_by_id_success() -> None:
+    mock_result = {"content": {"text": "Hello world"}}
+
+    with patch("glean.agent_toolkit.tools._common.api_client") as mock_api_client:
+        mock_client = MagicMock()
+        mock_client.client.documents.retrieve.return_value = mock_result
+        mock_api_client.return_value.__enter__.return_value = mock_client
+
+        result = read_document(document_id="glean_123")
+
+        assert result == {"result": mock_result}
+        mock_client.client.documents.retrieve.assert_called_once()
+        sent = mock_client.client.documents.retrieve.call_args.kwargs["request"]
+        assert isinstance(sent, models.GetDocumentsRequest)
+        assert len(sent.document_specs) == 1
+        assert isinstance(sent.document_specs[0], models.DocumentSpec2)
+        assert sent.document_specs[0].id == "glean_123"
+        assert models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT in (
+            sent.include_fields or []
+        )
+
+
+def test_read_document_by_url_success() -> None:
+    mock_result = {"content": {"text": "Hello world"}}
+
+    with patch("glean.agent_toolkit.tools._common.api_client") as mock_api_client:
+        mock_client = MagicMock()
+        mock_client.client.documents.retrieve.return_value = mock_result
+        mock_api_client.return_value.__enter__.return_value = mock_client
+
+        result = read_document(url="https://docs.google.com/document/d/REDACTED")
+
+        assert result == {"result": mock_result}
+        mock_client.client.documents.retrieve.assert_called_once()
+        sent = mock_client.client.documents.retrieve.call_args.kwargs["request"]
+        assert isinstance(sent, models.GetDocumentsRequest)
+        assert len(sent.document_specs) == 1
+        assert isinstance(sent.document_specs[0], models.DocumentSpec1)
+        assert sent.document_specs[0].url == "https://docs.google.com/document/d/REDACTED"
+        assert models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT in (
+            sent.include_fields or []
+        )
+
+
+def test_read_document_invalid_params() -> None:
+    result = read_document()
+    assert result["error"].startswith("Provide exactly one")
+
+    result = read_document(document_id="glean_1", url="https://example.com")
+    assert result["error"].startswith("Provide exactly one")
+
+
+def test_read_document_api_exception() -> None:
+    with patch("glean.agent_toolkit.tools._common.api_client") as mock_api_client:
+        mock_client = MagicMock()
+        mock_client.client.documents.retrieve.side_effect = Exception("API Error")
+        mock_api_client.return_value.__enter__.return_value = mock_client
+
+        result = read_document(url="https://unknown.example.com/abc")
+        assert result["error"] == "API Error"
+        assert result["result"] is None


### PR DESCRIPTION
### TL;DR

Added a new `read_document` tool that allows retrieving the full content of a document by ID or URL.

### What changed?

- Added a new `read_document` tool that can fetch complete document content using either a document ID or URL
- Updated documentation in README.md to include the new tool and its prerequisites
- Added documentation about required admin settings: `queryapi.getDocuments.enabled` and `queryapi.getDocuments.content.enabled`
- Renamed `glean_search` to `search` in documentation for consistency
- Added comprehensive unit tests for the new tool

### How to test?

1. Ensure admin settings are enabled in your Glean instance:
   - `queryapi.getDocuments.enabled`
   - `queryapi.getDocuments.content.enabled`
2. Test retrieving a document by ID:
   ```python
   result = read_document(document_id="glean_123456789")
   ```
3. Test retrieving a document by URL:
   ```python
   result = read_document(url="https://docs.google.com/document/d/REDACTED")
   ```

### Why make this change?

This tool enhances the toolkit's capabilities by allowing agents to access the full content of specific documents, rather than just search snippets. This is particularly useful for in-depth document analysis and when agents need to work with complete document content.