### PR TITLE
fix(deps): add [all] extra to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ openai = ["openai>=1.0.0,<2.0", "openai-agents>=0.0.11,<1.0"]
 adk = ["google-adk>=1.7.0,<2.0"]
 langchain = ["langchain>=0.1.0,<1.0"]
 crewai = ["crewai>=0.28.0,<1.0"]
+all = [
+  "openai>=1.0.0,<2.0",
+  "openai-agents>=0.0.11,<1.0",
+  "langchain>=0.1.0,<1.0",
+  "crewai>=0.28.0,<1.0",
+  "google-adk>=1.7.0,<2.0",
+]
 codespell = ["codespell>=2.2.6,<3.0"]
 lint = ["ruff>=0.5,<1.0"]
 typing = ["pyright>=1.1.370,<2.0"]


### PR DESCRIPTION
## Summary
- Adds `[all]` extra under `[project.optional-dependencies]` combining openai, adk, langchain, crewai
- Fixes `pip install glean-agent-toolkit[all]` silently installing zero optional deps

## Fixes
CHK-001 from EVAL-CHECKLIST.md

## Test plan
- [ ] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` exits 0
- [ ] `uv run pytest tests/ -x -q` passes