### PR TITLE
docs: fix retry environment variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and k
 
 ### Retry configuration (env vars)
 
-| Variable                    | Default | Description                    | Example |
-| --------------------------- | ------- | ------------------------------ | ------- |
-| `GLEAN_RETRY_INITIAL`       | `1.0`   | Initial backoff in seconds     | `0.5`   |
-| `GLEAN_RETRY_MAX`           | `50.0`  | Maximum backoff in seconds     | `8`     |
-| `GLEAN_RETRY_MULTIPLIER`    | `1.1`   | Exponential backoff multiplier | `2.0`   |
-| `GLEAN_RETRY_JITTER_MS`     | `100`   | Random jitter in milliseconds  | `250`   |
-| `GLEAN_RETRY_ON_RATE_LIMIT` | `true`  | Retry on HTTP 429 rate limits  | `true`  |
+| Variable                  | Default | Description                                              | Example |
+| ------------------------- | ------- | -------------------------------------------------------- | ------- |
+| `GLEAN_RETRY_INITIAL`     | `1.0`   | Initial backoff interval in seconds                      | `0.5`   |
+| `GLEAN_RETRY_MAX`         | `50.0`  | Maximum backoff interval in seconds                      | `8`     |
+| `GLEAN_RETRY_MULTIPLIER`  | `1.1`   | Backoff multiplier/exponent                              | `2.0`   |
+| `GLEAN_RETRY_MAX_ELAPSED` | `60.0`  | Total time limit in seconds before giving up on retries  | `30.0`  |
 
 Retries cover transient failures such as HTTP 429/5xx and connection timeouts. Set these before constructing any Glean client usage.
 
@@ -31,8 +30,7 @@ Retries cover transient failures such as HTTP 429/5xx and connection timeouts. S
 export GLEAN_RETRY_INITIAL=0.5
 export GLEAN_RETRY_MAX=8
 export GLEAN_RETRY_MULTIPLIER=2.0
-export GLEAN_RETRY_JITTER_MS=250
-export GLEAN_RETRY_ON_RATE_LIMIT=true
+export GLEAN_RETRY_MAX_ELAPSED=30.0
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary
- Removes `GLEAN_RETRY_JITTER_MS` and `GLEAN_RETRY_ON_RATE_LIMIT` from README (never implemented in code)
- Adds `GLEAN_RETRY_MAX_ELAPSED` which is read by code but was undocumented
- Documents all four actual retry env vars with accurate defaults

## Verified against
`src/glean/agent_toolkit/tools/_common.py` `_build_retry_config()` function

## Fixes
CHK-005 from EVAL-CHECKLIST.md

## Test plan
- [ ] README env var table lists exactly: GLEAN_RETRY_INITIAL, GLEAN_RETRY_MAX, GLEAN_RETRY_MULTIPLIER, GLEAN_RETRY_MAX_ELAPSED
- [ ] No mention of GLEAN_RETRY_JITTER_MS or GLEAN_RETRY_ON_RATE_LIMIT in README