### PR TITLE
fix(release): correct broken version_files path in .cz.toml

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -4,5 +4,4 @@ version = "0.4.0"
 tag_format = "$version"
 version_files = [
   "pyproject.toml:version",
-  "glean/toolkit/__init__.py:__version__",
 ]


### PR DESCRIPTION
## Summary
- Removes `version_files = ["glean/toolkit/__init__.py:__version__"]` which points to a non-existent path
- Actual version is declared in `pyproject.toml` as `version = "0.4.0"` and read at runtime via `importlib.metadata`
- `pyproject.toml:version` was already present as the first entry and is the correct sole entry — the broken path is redundant and wrong

## Fixes
CHK-006 from EVAL-CHECKLIST.md

## Test plan
- [ ] `.cz.toml` no longer references `glean/toolkit/__init__.py`
- [ ] `uv run cz version --project` shows the correct version (0.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)