### PR TITLE
Fix ADK read_document compatibility and preserve alias fields in tool outputs

### DIFF
--- a/src/glean/agent_toolkit/tools/_common.py
+++ b/src/glean/agent_toolkit/tools/_common.py
@@ -115,8 +115,34 @@ def run_tool(
                 name=tool_display_name,
                 parameters=parameters,
             )
-        return {"result": result}
+        return {"result": serialize_tool_result(result)}
     except ValueError as e:
         return {"error": f"Parameter validation error: {str(e)}", "result": None}
     except Exception as e:
         return {"error": str(e), "result": None}
+
+
+def serialize_tool_result(value: Any) -> Any:
+    """Normalize SDK response payloads into JSON-like data.
+
+    This keeps field aliases (for example ``camelCase``) so downstream adapters
+    that rely on plain dictionaries do not drop values.
+    """
+    if value is None:
+        return None
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump(by_alias=True)
+        except TypeError:
+            dumped = model_dump()
+        return serialize_tool_result(dumped)
+
+    if isinstance(value, dict):
+        return {key: serialize_tool_result(item) for key, item in value.items()}
+
+    if isinstance(value, (list, tuple, set)):
+        return [serialize_tool_result(item) for item in value]
+
+    return value

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import Annotated, Any
 
 from pydantic import Field
 
@@ -10,19 +10,6 @@ import glean.agent_toolkit.tools._common as common
 from glean.agent_toolkit.decorators import tool_spec
 from glean.api_client import models
 from glean.api_client.client_documents import ClientDocuments
-
-
-class ReadDocumentSuccess(TypedDict):
-    """Successful read document result payload."""
-
-    result: models.GetDocumentsResponse
-
-
-class ReadDocumentError(TypedDict):
-    """Error result payload for read document."""
-
-    error: str
-    result: None
 
 
 @tool_spec(
@@ -53,7 +40,7 @@ def read_document(
             ],
         ),
     ] = None,
-) -> ReadDocumentSuccess | ReadDocumentError:
+) -> dict[str, Any]:
     """Fetch full document content using the Glean Client API.
 
     One of document_id or url must be provided. If both or neither are provided,
@@ -84,6 +71,6 @@ def read_document(
 
             result = documents_client.retrieve(request=request)
 
-        return {"result": result}
+        return {"result": common.serialize_tool_result(result)}
     except Exception as e:
         return {"error": str(e), "result": None}

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -143,6 +143,17 @@ def test_adk_adapter_integration() -> None:
     assert hasattr(tool, "schema")
 
 
+@pytest.mark.skipif(not HAS_ADK, reason="Google ADK not installed")
+def test_read_document_as_adk_tool() -> None:
+    """Ensure read_document can be adapted for ADK function calling."""
+    from glean.agent_toolkit.tools.read_document import read_document
+
+    tool = read_document.as_adk_tool()
+
+    assert getattr(tool, "name", "") == "read_document"
+    assert callable(getattr(tool, "func", lambda: None))
+
+
 def test_langchain_adapter_import_error() -> None:
     """Test LangChain adapter import error only when LangChain is not available."""
     if HAS_LANGCHAIN:

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+from glean.agent_toolkit.tools._common import run_tool, serialize_tool_result
+
+
+class _AliasModel:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def model_dump(self, by_alias: bool = False) -> dict[str, object]:
+        if by_alias:
+            return {"camelCaseField": self.value}
+        return {"snake_case_field": self.value}
+
+
+def test_serialize_tool_result_recursively_uses_aliases() -> None:
+    payload = {
+        "items": [_AliasModel("a"), _AliasModel("b")],
+        "nested": _AliasModel({"child": _AliasModel("c")}),
+    }
+
+    result = serialize_tool_result(payload)
+
+    assert result == {
+        "items": [{"camelCaseField": "a"}, {"camelCaseField": "b"}],
+        "nested": {"camelCaseField": {"child": {"camelCaseField": "c"}}},
+    }
+
+
+def test_run_tool_serializes_sdk_response() -> None:
+    with patch("glean.agent_toolkit.tools._common.api_client") as mock_api_client:
+        mock_client = MagicMock()
+        mock_client.client.tools.run.return_value = _AliasModel("value")
+        mock_api_client.return_value.__enter__.return_value = mock_client
+
+        result = run_tool("Glean Search", {})
+
+        assert result.get("error") is None
+        assert result["result"] == {"camelCaseField": "value"}

--- a/tests/tools/test_read_document.py
+++ b/tests/tools/test_read_document.py
@@ -68,3 +68,21 @@ def test_read_document_api_exception() -> None:
         result = read_document(url="https://unknown.example.com/abc")
         assert result["error"] == "API Error"
         assert result["result"] is None
+
+
+def test_read_document_serializes_model_with_aliases() -> None:
+    class FakeResponseModel:
+        def model_dump(self, by_alias: bool = False) -> dict[str, object]:
+            if by_alias:
+                return {"fullTextList": ["hello"]}
+            return {"full_text_list": ["hello"]}
+
+    with patch("glean.agent_toolkit.tools._common.api_client") as mock_api_client:
+        mock_client = MagicMock()
+        mock_client.client.documents.retrieve.return_value = FakeResponseModel()
+        mock_api_client.return_value.__enter__.return_value = mock_client
+
+        result = read_document(document_id="glean_123")
+
+        assert result.get("error") is None
+        assert result["result"] == {"fullTextList": ["hello"]}


### PR DESCRIPTION
Co-authored with @dhruv7539 — this is a rebase of #25 onto current main to pick up the `adk.py` import fix (the only CI failure there was a pyright error from an import path that was already corrected on main: `from google.adk.tools import FunctionTool` → `from google.adk.tools.function_tool import FunctionTool`).

All original changes and authorship are preserved.

---

## Summary

- Normalize SDK response objects to plain JSON-like data with `model_dump(by_alias=True)` before returning tool payloads — this keeps camelCase field aliases (e.g. `fullTextList`) that downstream adapters expect
- Remove `ReadDocumentSuccess`/`ReadDocumentError` TypedDicts from `read_document.py`; use `dict[str, Any]` consistently (addresses CHK-032)
- Add `serialize_tool_result()` helper used by both `run_tool()` and `read_document`
- Add regression tests for alias-preserving serialization and ADK tool conversion

Closes #22
Closes #23
Closes #25