### PR TITLE
fix: remove pydantic BaseModel from adapters public API

### DIFF
--- a/src/glean/agent_toolkit/adapters/__init__.py
+++ b/src/glean/agent_toolkit/adapters/__init__.py
@@ -1,7 +1,5 @@
 """Adapters for converting tool specifications to framework-specific formats."""
 
-from pydantic import BaseModel
-
 from glean.agent_toolkit.adapters.adk import ADKAdapter
 from glean.agent_toolkit.adapters.base import BaseAdapter
 from glean.agent_toolkit.adapters.crewai import CrewAIAdapter
@@ -20,5 +18,4 @@ __all__ = [
     "OpenAIAdapter",
     "OpenAIToolDef",
     "OpenAIFunctionDef",
-    "BaseModel",
 ]


### PR DESCRIPTION
## Summary

- Removes `BaseModel` from `__all__` in `adapters/__init__.py`
- Removes the unused `from pydantic import BaseModel` import

`BaseModel` is a pydantic implementation detail, not part of the glean-agent-toolkit public API. Exporting it leaks a third-party type into the public surface and creates an implicit dependency on pydantic for any consumer that does `from glean.agent_toolkit.adapters import *`.

Closes CHK-012

## Test plan
- [x] All 129 tests pass, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)