### PR TITLE
fix: export Registry from top-level package

### DIFF
--- a/src/glean/agent_toolkit/__init__.py
+++ b/src/glean/agent_toolkit/__init__.py
@@ -8,7 +8,7 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.registry import get_registry
+from glean.agent_toolkit.registry import Registry, get_registry
 from glean.agent_toolkit.spec import ToolSpec
 
 from . import adapters
@@ -16,6 +16,7 @@ from . import adapters
 __all__ = [
     "tool_spec",
     "get_registry",
+    "Registry",
     "ToolSpec",
     "adapters",
     "__version__",


### PR DESCRIPTION
## Summary

- Imports `Registry` in `glean/agent_toolkit/__init__.py`
- Adds `Registry` to `__all__`

`get_registry()` is public API but its return type was not importable, making it impossible to write type-annotated code like:

```python
from glean.agent_toolkit import Registry, get_registry

registry: Registry = get_registry()
```

Closes CHK-019

## Test plan
- [x] All 129 tests pass, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)