### PR TITLE
fix: use is not None checks in read_document validation

### DIFF
--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -46,7 +46,7 @@ def read_document(
     One of document_id or url must be provided. If both or neither are provided,
     an error will be returned.
     """
-    if (document_id and url) or (not document_id and not url):
+    if (document_id is not None and url is not None) or (document_id is None and url is None):
         return {
             "error": "Provide exactly one of document_id or url",
             "result": None,
@@ -58,7 +58,7 @@ def read_document(
 
             include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
 
-            if document_id:
+            if document_id is not None:
                 request = models.GetDocumentsRequest(
                     document_specs=[models.DocumentSpec2(id=document_id)],
                     include_fields=include_fields,


### PR DESCRIPTION
## Summary

- Replaces truthy checks with explicit `is not None` / `is None` checks in `read_document`
- Fixes both the validation guard and the routing branch (`if document_id:` → `if document_id is not None:`)

With the old truthy checks, `document_id=""` was indistinguishable from `document_id=None` — an empty string would silently fall through to the `url` branch (or trigger the wrong validation error). `is not None` correctly captures the intent: was the argument provided or not?

Closes CHK-017

## Test plan
- [x] All 129 tests pass, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)