### PR TITLE
docs: remove dead cli.py reference and add web_search prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,7 @@ src/
 │     ├─ registry.py
 │     ├─ spec.py
 │     ├─ adapters/
-│     ├─ tools/
-│     └─ cli.py
+│     └─ tools/
 ├─ tests/
 └─ docs/
 ```

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -45,6 +45,11 @@ This guide summarizes requirements for your organization's Glean instance to use
 - Connectors: One or more code hosts (GitHub, GitLab, Bitbucket, Azure Repos)
 - Admin toggles: Code Search enabled for your organization's Glean instance and available to Client API
 
+### `web_search`
+
+- No connector required — searches the public web via Glean's web search capability
+- Admin toggles: Web search enabled for Client API
+
 ## Verification checklist
 
 - Confirm Client API access with a simple `search` call


### PR DESCRIPTION
## Summary

- **CHK-021**: Removes `cli.py` from the project structure diagram in `CONTRIBUTING.md` — the file does not exist
- **CHK-026**: Adds a `web_search` section to `docs/prerequisites.md` — it was the only built-in tool without a prerequisites entry

## Test plan
- [x] Docs-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)