### PR TITLE
fix: align publish workflow tag trigger with commitizen tag format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Commitizen `tag_format = "\$version"` produces tags without a `v` prefix (e.g. `0.4.0`, `0.3.0`). The publish workflow was triggering on `v[0-9]*.[0-9]*.[0-9]*`, which never matched — meaning all previous releases were published manually via `workflow_dispatch`, not automatically on tag push.

**Before:** `'v[0-9]*.[0-9]*.[0-9]*'` (never matches commitizen tags)
**After:** `'[0-9]*.[0-9]*.[0-9]*'` (matches `0.4.0`, `0.5.0`, etc.)

Closes CHK-024

## Test plan
- [x] Verified existing tags (`0.4.0`, `0.3.0`, `0.2.0`) match the new pattern
- [x] Verified `.cz.toml` `tag_format = "\$version"` produces tags without `v` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)