### PR TITLE
fix: correct web search stub tool name to 'Gemini Web Search'

### DIFF
--- a/src/glean/agent_toolkit/tools/web_search.py
+++ b/src/glean/agent_toolkit/tools/web_search.py
@@ -55,4 +55,4 @@ def web_search(
     ctx = ctx or GleanContext()
     client = ctx.get_client()
     parameters = convert_to_tool_params(query=query)
-    return run_tool("Web Browser", parameters, client=client)
+    return run_tool("Gemini Web Search", parameters, client=client)


### PR DESCRIPTION
## Summary

`web_search.py` was calling `run_tool("Web Browser", ...)` but the actual Glean stub tool is named `"Gemini Web Search"` (verified via `glean tools list`). This means web search was silently failing.

## Test plan

- [x] 7 web search tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)