### PR TITLE
fix(tools): stop closing shared Glean client on every tool call

### DIFF
--- a/src/glean/agent_toolkit/context.py
+++ b/src/glean/agent_toolkit/context.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import threading
+from types import TracebackType
 
 from glean.api_client import Glean
 from glean.api_client.utils import BackoffStrategy, RetryConfig
@@ -45,6 +47,11 @@ class GleanContext:
 
     Passed as the first parameter to every tool function. Adapters
     bind it via ``functools.partial`` so LLM frameworks never see it.
+
+    The context owns the lifecycle of the underlying :class:`Glean`
+    client: the client is created lazily, cached, and shared across
+    tool calls. Call :meth:`close` (or use the context as a context
+    manager) to release the client's HTTP resources when done.
     """
 
     def __init__(
@@ -66,39 +73,77 @@ class GleanContext:
         self._api_token = api_token
         self._server_url = server_url
         self._instance = instance
+        self._lock = threading.Lock()
 
     def get_client(self) -> Glean:
-        """Get a Glean client, creating one if needed."""
-        if self._client is not None:
-            return self._client
+        """Get a Glean client, creating one if needed.
 
-        api_token = self._api_token or os.getenv("GLEAN_API_TOKEN")
+        The client is created lazily on first use, cached, and reused
+        for the lifetime of this context. Creation is thread-safe.
+        """
+        with self._lock:
+            if self._client is not None:
+                return self._client
 
-        if self._server_url is not None or self._instance is not None:
-            server_url = self._server_url
-            instance = self._instance
-        else:
-            server_url = os.getenv("GLEAN_SERVER_URL")
-            instance = os.getenv("GLEAN_INSTANCE")
+            api_token = self._api_token or os.getenv("GLEAN_API_TOKEN")
 
-        if not api_token:
-            raise ValueError("GLEAN_API_TOKEN environment variable is required")
+            if self._server_url is not None or self._instance is not None:
+                server_url = self._server_url
+                instance = self._instance
+            else:
+                server_url = os.getenv("GLEAN_SERVER_URL")
+                instance = os.getenv("GLEAN_INSTANCE")
 
-        if server_url:
-            client = Glean(
-                api_token=api_token,
-                server_url=server_url,
-                retry_config=_build_retry_config(),
-            )
-            self._client = client
-            return client
-        elif instance:
-            client = Glean(
-                api_token=api_token,
-                instance=instance,
-                retry_config=_build_retry_config(),
-            )
-            self._client = client
-            return client
-        else:
-            raise ValueError("GLEAN_SERVER_URL or GLEAN_INSTANCE environment variable is required")
+            if not api_token:
+                raise ValueError("GLEAN_API_TOKEN environment variable is required")
+
+            if server_url:
+                client = Glean(
+                    api_token=api_token,
+                    server_url=server_url,
+                    retry_config=_build_retry_config(),
+                )
+                self._client = client
+                return client
+            elif instance:
+                client = Glean(
+                    api_token=api_token,
+                    instance=instance,
+                    retry_config=_build_retry_config(),
+                )
+                self._client = client
+                return client
+            else:
+                raise ValueError(
+                    "GLEAN_SERVER_URL or GLEAN_INSTANCE environment variable is required"
+                )
+
+    def close(self) -> None:
+        """Close the underlying Glean client and release HTTP resources.
+
+        Safe to call multiple times. After closing, the next
+        :meth:`get_client` call creates a fresh client.
+        """
+        with self._lock:
+            client = self._client
+            self._client = None
+
+        if client is None:
+            return
+
+        # Glean.__exit__ closes the underlying httpx client (when the
+        # SDK owns it) and clears internal references.
+        client.__exit__(None, None, None)
+
+    def __enter__(self) -> GleanContext:
+        """Enter the context manager, returning this context."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the context manager, closing the underlying client."""
+        self.close()

--- a/src/glean/agent_toolkit/tools/_common.py
+++ b/src/glean/agent_toolkit/tools/_common.py
@@ -150,14 +150,13 @@ def run_tool(
 
             client = GleanContext().get_client()
 
-        with client as g_client:
-            from glean.agent_toolkit.tools._compat import resolve_method
+        from glean.agent_toolkit.tools._compat import resolve_method
 
-            run_fn = resolve_method(g_client.client.tools, "run", "execute")
-            result = run_fn(
-                name=tool_display_name,
-                parameters=parameters,
-            )
+        run_fn = resolve_method(client.client.tools, "run", "execute")
+        result = run_fn(
+            name=tool_display_name,
+            parameters=parameters,
+        )
         return make_ok(serialize_tool_result(result))
     except Exception as e:
         error_type, suggested_action = _classify_error(e)

--- a/src/glean/agent_toolkit/tools/chat.py
+++ b/src/glean/agent_toolkit/tools/chat.py
@@ -96,10 +96,9 @@ def glean_chat(
     client = ctx.get_client()
 
     def _do_chat() -> dict[str, Any]:
-        with client as g_client:
-            response = g_client.client.chat.create(
-                messages=[{"fragments": [{"text": message}]}],
-            )
+        response = client.client.chat.create(
+            messages=[{"fragments": [{"text": message}]}],
+        )
         answer = _extract_answer(response)
         sources = _extract_sources(response)
         return ChatResult(answer=answer, sources=sources).model_dump()

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -71,26 +71,25 @@ def read_document(
     client = ctx.get_client()
 
     def _do_read() -> Any:
-        with client as g_client:
-            documents_client: ClientDocuments = g_client.client.documents
+        documents_client: ClientDocuments = client.client.documents
 
-            include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
+        include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
 
-            if document_id is not None:
-                request = models.GetDocumentsRequest(
-                    document_specs=[models.DocumentSpec2(id=document_id)],
-                    include_fields=include_fields,
-                )
-            else:
-                request = models.GetDocumentsRequest(
-                    document_specs=[models.DocumentSpec1(url=common.clean_query(url or ""))],
-                    include_fields=include_fields,
-                )
+        if document_id is not None:
+            request = models.GetDocumentsRequest(
+                document_specs=[models.DocumentSpec2(id=document_id)],
+                include_fields=include_fields,
+            )
+        else:
+            request = models.GetDocumentsRequest(
+                document_specs=[models.DocumentSpec1(url=common.clean_query(url or ""))],
+                include_fields=include_fields,
+            )
 
-            from glean.agent_toolkit.tools._compat import resolve_method
+        from glean.agent_toolkit.tools._compat import resolve_method
 
-            retrieve_fn = resolve_method(documents_client, "retrieve", "get")
-            result = retrieve_fn(request=request)
+        retrieve_fn = resolve_method(documents_client, "retrieve", "get")
+        result = retrieve_fn(request=request)
 
         return common.serialize_tool_result(result)
 

--- a/tests/test_client_lifecycle.py
+++ b/tests/test_client_lifecycle.py
@@ -1,0 +1,92 @@
+"""Regression tests for Glean client lifecycle management.
+
+These tests use the REAL ``glean.api_client.Glean`` client (with HTTP
+mocked at the transport layer via pytest-httpx) rather than MagicMock.
+MagicMock has a no-op ``__exit__``, which hid a bug where every tool
+call ran inside ``with client:`` and the SDK's ``__exit__`` closed the
+shared httpx client, breaking all subsequent calls on the same context.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from glean.agent_toolkit.context import GleanContext
+from glean.agent_toolkit.tools.search import search
+
+SERVER_URL = "https://example.glean.com"
+TOOLS_CALL_URL = f"{SERVER_URL}/rest/api/v1/tools/call"
+
+
+@pytest.fixture
+def ctx() -> GleanContext:
+    """A context pointing at a fake server with a fake token."""
+    return GleanContext(api_token="fake-token", server_url=SERVER_URL)
+
+
+def _mock_tools_call(httpx_mock: HTTPXMock, count: int = 1) -> None:
+    for _ in range(count):
+        httpx_mock.add_response(
+            method="POST",
+            url=TOOLS_CALL_URL,
+            json={"rawResponse": {"results": []}},
+        )
+
+
+def test_second_tool_call_with_same_context_succeeds(
+    ctx: GleanContext, httpx_mock: HTTPXMock
+) -> None:
+    """Two sequential tool calls on ONE context must both succeed.
+
+    Regression: the first call used to close the shared client via
+    ``with client:``, making the second call raise
+    ``ValueError("client is required")`` from the SDK.
+    """
+    _mock_tools_call(httpx_mock, count=2)
+
+    first = search(ctx, query="a")
+    assert first["status"] == "ok", f"first call failed: {first['error']}"
+
+    second = search(ctx, query="a")
+    assert second["status"] == "ok", f"second call failed: {second['error']}"
+
+
+def test_client_still_usable_after_tool_call(ctx: GleanContext, httpx_mock: HTTPXMock) -> None:
+    """A tool call must not close or null the context's cached client."""
+    _mock_tools_call(httpx_mock, count=1)
+
+    client = ctx.get_client()
+    result = search(ctx, query="a")
+    assert result["status"] == "ok"
+
+    # Same cached client instance, with a live underlying httpx client.
+    assert ctx.get_client() is client
+    httpx_client = client.sdk_configuration.client
+    assert isinstance(httpx_client, httpx.Client)
+    assert not httpx_client.is_closed
+
+
+def test_close_closes_underlying_client(ctx: GleanContext) -> None:
+    """GleanContext.close() closes the underlying httpx client."""
+    client = ctx.get_client()
+    httpx_client = client.sdk_configuration.client
+    assert isinstance(httpx_client, httpx.Client)
+
+    ctx.close()
+
+    assert httpx_client.is_closed
+    # Idempotent.
+    ctx.close()
+
+
+def test_context_manager_closes_client() -> None:
+    """Using GleanContext as a context manager closes the client on exit."""
+    with GleanContext(api_token="fake-token", server_url=SERVER_URL) as ctx:
+        client = ctx.get_client()
+        httpx_client = client.sdk_configuration.client
+        assert isinstance(httpx_client, httpx.Client)
+        assert not httpx_client.is_closed
+
+    assert httpx_client.is_closed


### PR DESCRIPTION
## Bug

Calling any built-in tool twice with the same `GleanContext` fails: the first call succeeds, the second raises `ValueError("client is required")` from the SDK's `basesdk`. Since `get_tools()` creates one `GleanContext` and binds it into every adapter via `functools.partial`, this breaks all real agent usage after the first tool invocation (reproduced against glean-api-client 0.6.0).

## Mechanism

`GleanContext.get_client()` builds the Speakeasy `Glean` client without supplying an httpx client (`client_supplied=False`) and caches it. The tool implementations then executed API calls inside `with client as g_client:`:

- `src/glean/agent_toolkit/tools/_common.py` (`run_tool`, used by search/code_search/employee_search/gmail/outlook/calendar/web_search)
- `src/glean/agent_toolkit/tools/chat.py`
- `src/glean/agent_toolkit/tools/read_document.py`

The SDK's `__exit__` closes the underlying httpx client **and** sets `sdk_configuration.client = None` when the SDK owns the httpx client, and `__enter__` never recreates it. So the first tool call permanently destroyed the shared cached client.

## Fix (ownership model)

- Tools no longer enter the client's context manager; they call methods directly on the client.
- `GleanContext` now owns the client lifecycle:
  - lazy creation + caching is now thread-safe (`threading.Lock`)
  - new `close()` method (idempotent; a subsequent `get_client()` creates a fresh client)
  - `GleanContext` is itself a context manager (`__enter__`/`__exit__` close the underlying client)

No changes to adapters, decorators, registry, or other tool files.

## Test

New `tests/test_client_lifecycle.py` uses the **real** `glean.api_client.Glean` client with HTTP mocked at the transport layer via pytest-httpx — deliberately not MagicMock, whose no-op `__exit__` is exactly why the existing suite missed this. It asserts:

1. `search(ctx, query="a")` twice on the same context succeeds both times (fails with `ValueError` on the old code)
2. after a tool call the cached client's httpx client is still open
3. `close()` and context-manager usage close the underlying httpx client

Verified all four tests fail on the pre-fix code. Full suite: 162 passed, 4 skipped; ruff/pyright clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)