### PR TITLE
fix(crewai): pass args_schema to BaseTool so the LLM sees real parameters

### DIFF
--- a/src/glean/agent_toolkit/adapters/crewai.py
+++ b/src/glean/agent_toolkit/adapters/crewai.py
@@ -92,14 +92,17 @@ class GleanCrewAITool(BaseTool):  # type: ignore[misc]
             function: The function to call when the tool is invoked
             args_schema: Optional schema for the arguments
         """
-        super().__init__(name=name, description=description)
+        # ``args_schema`` must be passed to ``super().__init__`` (not assigned
+        # afterwards) because CrewAI generates the LLM-facing tool description
+        # during ``__init__``. Assigning it after the fact leaves the
+        # description built from ``_run(self, **kwargs)``, so agents would see
+        # a bogus ``kwargs`` parameter instead of the real arguments.
+        init_kwargs: dict[str, Any] = {"name": name, "description": description}
+        if args_schema is not None:
+            init_kwargs["args_schema"] = args_schema
+        super().__init__(**init_kwargs)
 
         self._function = function
-
-        # Only override ``args_schema`` when we actually created one; otherwise
-        # leave the placeholder so CrewAI can lazily generate a schema.
-        if args_schema is not None:
-            self.args_schema = args_schema
 
         object.__setattr__(self, "_tool_spec_ref", None)
 

--- a/tests/test_crewai_invocation.py
+++ b/tests/test_crewai_invocation.py
@@ -1,0 +1,110 @@
+"""Regression tests for CrewAI tool invocation using the real crewai package.
+
+These tests guard against the bug where ``GleanCrewAITool`` called
+``super().__init__`` without ``args_schema``. CrewAI generates the LLM-facing
+tool description during ``__init__``, so assigning ``args_schema`` afterwards
+left the description built from ``_run(self, **kwargs)`` — agents saw a bogus
+``kwargs`` parameter (with a ``ForwardRef('Any')`` type) instead of the tool's
+real parameters.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any
+
+import pytest
+
+try:
+    from glean.agent_toolkit.adapters.crewai import HAS_CREWAI
+except ImportError:  # pragma: no cover
+    HAS_CREWAI = False
+
+pytestmark = pytest.mark.skipif(not HAS_CREWAI, reason="CrewAI not installed")
+
+
+@pytest.fixture(autouse=True)
+def _glean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide dummy Glean credentials so client construction never fails."""
+    monkeypatch.setenv("GLEAN_INSTANCE", "test-instance")
+    monkeypatch.setenv("GLEAN_API_TOKEN", "test-token")
+
+
+def test_crewai_glean_search_description_names_real_parameters() -> None:
+    """The CrewAI-generated description must expose the real parameter names.
+
+    Before the fix, CrewAI derived the schema from ``_run(self, **kwargs)``,
+    producing ``Tool Arguments: {'kwargs': {... ForwardRef('Any')}}``.
+    """
+    from glean.agent_toolkit.tools import search
+
+    tool = search.as_crewai_tool()
+
+    # The generated description must name the actual parameters.
+    assert "query" in tool.description
+    assert "page_size" in tool.description
+
+    # And must not fall back to the catch-all ``_run`` signature.
+    assert "kwargs" not in tool.description
+    assert "ForwardRef" not in tool.description
+
+    # The args_schema itself must carry the real parameter names, with the
+    # required ``query`` parameter typed as ``str``. (Optional parameter
+    # types are intentionally not asserted here — see get_field_type in
+    # adapters/base.py.)
+    assert tool.args_schema is not None
+    schema = tool.args_schema.model_json_schema()
+    assert set(schema["properties"]) == {"query", "datasources", "filters", "page_size"}
+    assert schema["properties"]["query"]["type"] == "string"
+    assert "query" in schema.get("required", [])
+    assert "kwargs" not in schema["properties"]
+
+
+def test_crewai_glean_search_run_with_mocked_glean_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``tool.run(query=...)`` (the public CrewAI path) reaches the Glean layer."""
+    search_mod = importlib.import_module("glean.agent_toolkit.tools.search")
+
+    canned = {
+        "status": "ok",
+        "result": {"results": ["doc1"]},
+        "error": None,
+        "error_type": None,
+        "suggested_action": None,
+    }
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_tool(tool_display_name: str, parameters: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"name": tool_display_name, "parameters": parameters})
+        return canned
+
+    monkeypatch.setattr(search_mod, "run_tool", fake_run_tool)
+
+    tool = search_mod.search.as_crewai_tool()
+    output = tool.run(query="test")
+
+    assert len(calls) == 1
+    assert calls[0]["name"] == "Glean Search"
+    assert calls[0]["parameters"]["query"].value == "test"
+
+    assert json.loads(output) == canned
+
+
+def test_crewai_custom_tool_run_returns_result() -> None:
+    """A custom decorated tool executes through the public ``run`` path."""
+    from glean.agent_toolkit.decorators import tool_spec
+
+    @tool_spec(name="add", description="Add two integers")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    tool = add.as_crewai_tool()
+
+    # Description should name the real parameters, not ``kwargs``.
+    assert "'a'" in tool.description or '"a"' in tool.description
+    assert "kwargs" not in tool.description
+
+    result = tool.run(a=3, b=5)
+    assert result == "8"


### PR DESCRIPTION
## Problem

`GleanCrewAITool` called `super().__init__(name=..., description=...)` without `args_schema`, assigning it only after the fact. CrewAI generates the LLM-facing tool description during `BaseTool.__init__`, falling back to the `_run(self, **kwargs)` signature. Agents therefore saw:

```
Tool Arguments: {'kwargs': {'description': None, 'type': "ForwardRef('Any')"}}
```

instead of the tool's real parameters — the LLM was misinformed about how to call every converted tool (reproduced on crewai 0.203.2).

## Fix

Pass the generated pydantic `args_schema` into `super().__init__(...)` so CrewAI builds its description from the real schema. Verified empirically: `glean_search`'s generated description now lists `query`, `datasources`, `filters`, `page_size` with no `kwargs`/`ForwardRef`.

## Tests

New `tests/test_crewai_invocation.py` (real crewai, skipped only if crewai is not installed):
- Generated description and `args_schema` name the real parameters (`query: str` required) and contain no `kwargs`/`ForwardRef` — fails on the old code.
- Public `tool.run(query="test")` path with the Glean network layer monkeypatched returns the canned result.
- Custom `add(a, b)` tool through `tool.run(a=3, b=5)` returns `"8"` — description assertion fails on the old code.

Full suite: 161 passed, 4 skipped. Lint clean.

Note: optional-parameter types in the schema still degrade to `str` via `get_field_type` in `adapters/base.py`; that is tracked separately and intentionally not asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)