### PR TITLE
fix(langchain): use StructuredTool so converted tools are invocable

### DIFF
--- a/src/glean/agent_toolkit/adapters/langchain.py
+++ b/src/glean/agent_toolkit/adapters/langchain.py
@@ -15,11 +15,10 @@ if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
 
 if TYPE_CHECKING:
-    from langchain_core.tools import Tool as LangchainTool  # pragma: no cover
+    from langchain_core.tools import StructuredTool as LangchainTool  # pragma: no cover
 else:
     LangchainTool = Any  # type: ignore  # noqa: N816
 
-from pydantic import Field as PydanticField  # type: ignore
 from pydantic import create_model as pydantic_create_model
 
 ToolClass: Any = object
@@ -27,12 +26,13 @@ Field: Any = object
 create_model = pydantic_create_model
 
 
-class _FallbackLangchainTool:
-    """Fallback for langchain.tools.Tool."""
+class _FallbackStructuredTool:
+    """Fallback for langchain_core.tools.StructuredTool."""
 
     name: str
     description: str
     func: Any
+    coroutine: Any
     args_schema: Any
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D107
@@ -50,16 +50,16 @@ def _fallback_pydantic_create_model(*args: Any, **kwargs: Any) -> Any:
 
 
 try:
-    from langchain_core.tools import Tool as _ActualLangchainToolImport  # type: ignore
+    from langchain_core.tools import StructuredTool as _ActualStructuredToolImport  # type: ignore
     from pydantic import Field as _ActualPydanticFieldImport  # type: ignore
     from pydantic import create_model as _actual_pydantic_create_model_import
 
-    ToolClass = _ActualLangchainToolImport
+    ToolClass = _ActualStructuredToolImport
     Field = _ActualPydanticFieldImport
     create_model = _actual_pydantic_create_model_import
     HAS_LANGCHAIN = True
 except ImportError:  # pragma: no cover
-    ToolClass = _FallbackLangchainTool  # type: ignore[assignment]
+    ToolClass = _FallbackStructuredTool  # type: ignore[assignment]
     Field = _fallback_pydantic_field
     create_model = _fallback_pydantic_create_model
     HAS_LANGCHAIN = False
@@ -91,13 +91,17 @@ class LangChainAdapter(BaseAdapter[LangChainToolType]):
     def to_tool(self) -> Any:
         """Convert to LangChain tool format.
 
+        Builds a ``StructuredTool`` so multi-argument tools are invocable
+        (the legacy single-input ``Tool`` rejects dict inputs with more
+        than one key and calls its func positionally).
+
         LangChain's tool contract expects string returns.  The wrapper
         JSON-serializes whatever the underlying function produces.
         When an async_function is available, passes it as ``coroutine``
         so LangChain can ``await`` it natively.
 
         Returns:
-            LangChain Tool instance
+            LangChain StructuredTool instance
         """
         original_func = self.tool_spec.function
         async_func = self.tool_spec.async_function
@@ -118,11 +122,17 @@ class LangChainAdapter(BaseAdapter[LangChainToolType]):
                 return result
             return json.dumps(result, default=str)
 
+        args_schema = self._create_args_schema()
+        if args_schema is None:
+            # StructuredTool requires an args_schema; use an empty model
+            # for tools that take no arguments.
+            args_schema = cast("type[BaseModel]", create_model(f"{self.tool_spec.name}Schema"))
+
         tool_kwargs: dict[str, Any] = {
             "name": self.tool_spec.name,
             "description": self.tool_spec.description,
             "func": _string_wrapper,
-            "args_schema": self._create_args_schema(),
+            "args_schema": args_schema,
         }
         if async_func is not None:
             tool_kwargs["coroutine"] = _async_string_wrapper

--- a/tests/test_langchain_invocation.py
+++ b/tests/test_langchain_invocation.py
@@ -1,0 +1,101 @@
+"""Regression tests: converted LangChain tools must be invocable.
+
+The adapter previously built the legacy single-input
+``langchain_core.tools.Tool``, which rejects multi-key dict inputs
+("Too many arguments to single-input tool") and calls its func
+positionally (breaking the kwargs-only wrappers). These tests exercise
+LangChain's own ``invoke``/``ainvoke`` path end-to-end against the real
+langchain-core package, mocking the network at the Glean client layer.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from glean.agent_toolkit.decorators import tool_spec
+from glean.agent_toolkit.tools._common import ToolResult, make_ok
+from glean.agent_toolkit.tools.search import search
+
+CANNED_PAYLOAD = "CANNED_LANGCHAIN_PAYLOAD"
+
+
+@pytest.fixture
+def patched_run_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace the Glean network call with a canned ToolResult.
+
+    ``search`` binds ``run_tool`` into its module namespace at import
+    time, so patch it there. Env vars are set so the (unused) client
+    construction inside the tool does not fail.
+    """
+    monkeypatch.setenv("GLEAN_API_TOKEN", "test-token")
+    monkeypatch.setenv("GLEAN_INSTANCE", "test-instance")
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_tool(
+        tool_display_name: str,
+        parameters: dict[str, Any],
+        *,
+        client: Any = None,
+    ) -> ToolResult:
+        captured["tool_display_name"] = tool_display_name
+        captured["parameters"] = {name: param.value for name, param in parameters.items()}
+        return make_ok({"marker": CANNED_PAYLOAD})
+
+    # The tools package re-exports the `search` function under the same
+    # name as its module, so resolve the module object explicitly.
+    search_module = importlib.import_module("glean.agent_toolkit.tools.search")
+    monkeypatch.setattr(search_module, "run_tool", fake_run_tool)
+    return captured
+
+
+def test_as_langchain_tool_returns_structured_tool() -> None:
+    tool = search.as_langchain_tool()
+
+    assert isinstance(tool, StructuredTool)
+    assert tool.name == "glean_search"
+    assert tool.args_schema is not None
+
+
+def test_invoke_multi_arg_through_langchain(patched_run_tool: dict[str, Any]) -> None:
+    tool = search.as_langchain_tool()
+
+    result = tool.invoke({"query": "test", "page_size": 5})
+
+    assert isinstance(result, str)
+    assert CANNED_PAYLOAD in result
+    assert patched_run_tool["tool_display_name"] == "Glean Search"
+    assert patched_run_tool["parameters"]["query"] == "test"
+    assert patched_run_tool["parameters"]["pageSize"] == "5"
+
+
+async def test_ainvoke_multi_arg_through_langchain(patched_run_tool: dict[str, Any]) -> None:
+    tool = search.as_langchain_tool()
+
+    result = await tool.ainvoke({"query": "async test", "page_size": 5})
+
+    assert isinstance(result, str)
+    assert CANNED_PAYLOAD in result
+    assert patched_run_tool["parameters"]["query"] == "async test"
+    assert patched_run_tool["parameters"]["pageSize"] == "5"
+
+
+def test_custom_multi_arg_tool_invocable() -> None:
+    @tool_spec(name="test_lc_add", description="Add two integers.")
+    def add(a: int, b: int) -> int:
+        """Add two integers.
+
+        Args:
+            a: First addend.
+            b: Second addend.
+        """
+        return a + b
+
+    tool = add.as_langchain_tool()
+
+    assert isinstance(tool, StructuredTool)
+    assert tool.invoke({"a": 3, "b": 5}) == "8"


### PR DESCRIPTION
## Bug

`src/glean/agent_toolkit/adapters/langchain.py` built the legacy single-input `langchain_core.tools.Tool`, so **every** converted tool failed at runtime (reproduced on langchain-core 1.4.9):

- **Multi-arg tools**: `search.as_langchain_tool().invoke({"query": "x"})` raises `ToolException: Too many arguments to single-input tool glean_search.` — the legacy `Tool` only accepts a single input.
- **Single-arg tools**: `Tool` calls its `func` positionally, but the adapter's JSON-string wrappers are kwargs-only, raising `TypeError: _string_wrapper() takes 0 positional arguments but 1 was given`.

## Fix

Switch the adapter to `langchain_core.tools.StructuredTool`, preserving:

- name, description, and `args_schema` from `_create_args_schema()`
- the JSON-string-serializing sync wrapper as `func`
- the async wrapper as `coroutine` when `async_function` exists
- ctx binding via `functools.partial`
- the module's optional-import / ImportError-in-`__init__` pattern (fallback renamed to `_FallbackStructuredTool`)

Tools with no arguments get an empty args_schema model, since `StructuredTool` requires one. Also removes the unused `PydanticField` import.

## Tests

New `tests/test_langchain_invocation.py` runs against **real** langchain-core, mocking the network at the Glean client layer (`run_tool` in the search tool module):

1. `as_langchain_tool()` returns a `StructuredTool`
2. `tool.invoke({"query": "test", "page_size": 5})` through LangChain's own path returns the canned payload with query/pageSize delivered
3. Same via `await tool.ainvoke(...)`
4. A custom multi-arg `@tool_spec` tool invoked with `{"a": 3, "b": 5}` returns `"8"`

All four tests fail against the previous adapter and pass with this change. Full suite: 162 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)