### PR TITLE
fix(adapters): map anyOf/union and array item types correctly in get_field_type

### DIFF
--- a/src/glean/agent_toolkit/adapters/base.py
+++ b/src/glean/agent_toolkit/adapters/base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import operator
 from abc import ABC, abstractmethod
+from functools import reduce
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from glean.agent_toolkit.spec import ToolSpec
@@ -13,20 +15,56 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-def get_field_type(schema: dict[str, Any], *, use_date_types: bool = False) -> type:
+def get_field_type(schema: dict[str, Any], *, use_date_types: bool = False) -> Any:
     """Determine the Python type from a JSON schema property.
+
+    Handles scalar types, ``anyOf``/``oneOf`` unions (including the
+    ``Optional`` pattern emitted by Pydantic for parameters with a ``None``
+    default), typed arrays, objects, and enums. ``$ref`` schemas fall back
+    to :data:`~typing.Any`.
 
     Args:
         schema: JSON schema property definition.
         use_date_types: When ``True``, map ``date-time`` and ``date``
             string formats to :class:`~datetime.datetime` and
             :class:`~datetime.date` respectively.
+
+    Returns:
+        The Python type (or typing construct, e.g. ``list[str] | None``)
+        corresponding to the schema.
     """
-    if "enum" in schema:
-        return str
+    if not isinstance(schema, dict):
+        return Any
+
+    if "$ref" in schema:
+        return Any
+
+    union_members = schema.get("anyOf") or schema.get("oneOf")
+    if union_members:
+        has_null = False
+        member_types: list[Any] = []
+        for member in union_members:
+            if isinstance(member, dict) and member.get("type") == "null":
+                has_null = True
+                continue
+            member_type = get_field_type(member, use_date_types=use_date_types)
+            if member_type not in member_types:
+                member_types.append(member_type)
+
+        if not member_types:
+            result: Any = Any
+        else:
+            result = reduce(operator.or_, member_types)
+
+        if has_null:
+            return result | None
+        return result
 
     schema_type = schema.get("type", "string")
     schema_format = schema.get("format", "")
+
+    if "enum" in schema and schema_type == "string":
+        return str
 
     if schema_type == "string":
         if use_date_types:
@@ -46,9 +84,15 @@ def get_field_type(schema: dict[str, Any], *, use_date_types: bool = False) -> t
     elif schema_type == "boolean":
         return bool
     elif schema_type == "array":
-        return list
+        items = schema.get("items")
+        if isinstance(items, dict):
+            item_type = get_field_type(items, use_date_types=use_date_types)
+            return list[item_type]  # type: ignore[valid-type]
+        return list[Any]
     elif schema_type == "object":
-        return dict
+        return dict[str, Any]
+    elif schema_type == "null":
+        return type(None)
     else:
         return str
 

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -1,0 +1,155 @@
+"""Regression tests for JSON schema -> Python type mapping in get_field_type.
+
+Pydantic emits optional parameters as ``{"anyOf": [{...}, {"type": "null"}]}``
+with no top-level ``"type"`` key. Prior to the fix, get_field_type ignored
+``anyOf`` entirely and degraded every optional parameter to ``str``, which
+corrupted the args_schema used by the LangChain and CrewAI adapters.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from typing import Any, get_args, get_origin
+
+from glean.agent_toolkit.adapters.base import get_field_type
+
+
+def _is_union(annotation: Any) -> bool:
+    """True for both ``typing.Union[...]`` and PEP 604 ``X | Y`` unions."""
+    return get_origin(annotation) in (typing.Union, types.UnionType)
+
+
+def _is_optional_of(annotation: Any, inner_check: Any) -> bool:
+    """Return True if annotation is ``X | None`` where X satisfies inner_check.
+
+    ``inner_check`` may be a concrete type/typing construct to compare for
+    equality, or a callable predicate applied to the non-None member.
+    """
+    if not _is_union(annotation):
+        return False
+    args = [a for a in get_args(annotation) if a is not type(None)]
+    if type(None) not in get_args(annotation) or len(args) != 1:
+        return False
+    inner = args[0]
+    if callable(inner_check) and not isinstance(inner_check, type):
+        return bool(inner_check(inner))
+    return inner == inner_check
+
+
+class TestGetFieldType:
+    """Unit tests for get_field_type."""
+
+    def test_anyof_optional_str(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        assert get_field_type(schema) == (str | None)
+
+    def test_anyof_optional_list_of_str(self) -> None:
+        schema = {
+            "anyOf": [
+                {"items": {"type": "string"}, "type": "array"},
+                {"type": "null"},
+            ]
+        }
+        assert get_field_type(schema) == (list[str] | None)
+
+    def test_array_of_objects(self) -> None:
+        schema = {"type": "array", "items": {"type": "object"}}
+        assert get_field_type(schema) == list[dict[str, Any]]
+
+    def test_array_without_items(self) -> None:
+        result = get_field_type({"type": "array"})
+        assert get_origin(result) is list
+        assert get_args(result) == (Any,)
+
+    def test_nested_anyof(self) -> None:
+        schema = {
+            "anyOf": [
+                {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                {"type": "null"},
+            ]
+        }
+        result = get_field_type(schema)
+        assert _is_union(result)
+        assert set(get_args(result)) == {int, str, type(None)}
+
+    def test_general_union(self) -> None:
+        schema = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+        result = get_field_type(schema)
+        assert _is_union(result)
+        assert set(get_args(result)) == {int, str}
+
+    def test_scalar_types_preserved(self) -> None:
+        assert get_field_type({"type": "string"}) is str
+        assert get_field_type({"type": "integer"}) is int
+        assert get_field_type({"type": "number"}) is float
+        assert get_field_type({"type": "boolean"}) is bool
+        assert get_field_type({"type": "object"}) == dict[str, Any]
+
+    def test_ref_falls_back_to_any(self) -> None:
+        assert get_field_type({"$ref": "#/$defs/SomeModel"}) is Any
+
+    def test_string_enum_maps_to_str(self) -> None:
+        assert get_field_type({"type": "string", "enum": ["a", "b"]}) is str
+
+    def test_use_date_types_preserved(self) -> None:
+        from datetime import date, datetime
+
+        assert (
+            get_field_type({"type": "string", "format": "date-time"}, use_date_types=True)
+            is datetime
+        )
+        assert get_field_type({"type": "string", "format": "date"}, use_date_types=True) is date
+        assert get_field_type({"type": "string", "format": "date-time"}) is str
+
+    def test_anyof_optional_datetime_with_date_types(self) -> None:
+        from datetime import datetime
+
+        schema = {
+            "anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}],
+        }
+        assert get_field_type(schema, use_date_types=True) == (datetime | None)
+
+
+class TestSearchArgsSchemaIntegration:
+    """Integration: the built-in search tool's LangChain args_schema."""
+
+    def _build_schema(self) -> Any:
+        from glean.agent_toolkit.adapters.langchain import LangChainAdapter
+        from glean.agent_toolkit.tools import search
+
+        adapter = LangChainAdapter(search.tool_spec)
+        model = adapter._create_args_schema()
+        assert model is not None
+        return model
+
+    def test_datasources_is_optional_list_of_str(self) -> None:
+        model = self._build_schema()
+        annotation = model.model_fields["datasources"].annotation
+        assert _is_optional_of(annotation, list[str]), (
+            f"datasources should be list[str] | None, got {annotation!r}"
+        )
+
+    def test_filters_is_optional_list_of_dict(self) -> None:
+        model = self._build_schema()
+        annotation = model.model_fields["filters"].annotation
+
+        def _is_list_of_dict(inner: Any) -> bool:
+            if get_origin(inner) is not list:
+                return False
+            (item,) = get_args(inner)
+            return item is dict or get_origin(item) is dict
+
+        assert _is_optional_of(annotation, _is_list_of_dict), (
+            f"filters should be list[dict[...]] | None, got {annotation!r}"
+        )
+
+    def test_page_size_is_int(self) -> None:
+        model = self._build_schema()
+        assert model.model_fields["page_size"].annotation is int
+
+    def test_query_is_required_str(self) -> None:
+        model = self._build_schema()
+        field = model.model_fields["query"]
+        assert field.annotation is str
+        assert field.is_required()


### PR DESCRIPTION
## Summary

`get_field_type` in `src/glean/agent_toolkit/adapters/base.py` mapped JSON schema fragments to Python types but ignored `anyOf` unions. Pydantic emits optional parameters as `{"anyOf": [{...}, {"type": "null"}]}` with no top-level `"type"` key, so every optional parameter silently degraded to `str`.

Concretely, for the built-in `search` tool:
- `datasources` should be `list[str] | None` but became `str`
- `filters` should be `list[dict] | None` but became `str`

This corrupted the `args_schema` used by the LangChain adapter and the CrewAI adapter. Arrays also lost their item types (`list` instead of `list[T]`).

## Changes

`get_field_type` (confined to `adapters/base.py`, signature unchanged) now handles:
- `anyOf`/`oneOf`: the Optional pattern maps to `X | None`; general unions map to a union of the mapped member types
- Arrays: `items` mapped recursively to `list[T]`; `list[Any]` when `items` is absent
- Objects: `dict[str, Any]`
- `$ref`: falls back to `Any` instead of degrading to `str`
- Enums and `use_date_types` (`date`/`date-time`) behavior preserved, including inside `anyOf` members

## Tests

New `tests/test_field_types.py`:
- Unit tests for anyOf-optional scalars/lists, arrays of objects, arrays without items, nested anyOf, general unions, `$ref` fallback, enum, and `use_date_types`
- Integration tests building the LangChain `args_schema` for the built-in `search` tool, asserting `datasources` is `list[str] | None`, `filters` is `list[dict[...]] | None`, `page_size` is `int`, and `query` is a required `str`

Verified the regression tests fail against the old code (anyOf-optional, nested anyOf, array item types, and both integration assertions all fail pre-fix). Full suite: 173 passed, 4 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)