### PR TITLE
fix(openai): sanitize strict schemas and isolate per-tool conversion failures

### DIFF
--- a/src/glean/agent_toolkit/__init__.py
+++ b/src/glean/agent_toolkit/__init__.py
@@ -7,6 +7,7 @@ Universal Tool/Action Toolkit for Glean agent frameworks.
 from __future__ import annotations
 
 import logging
+import warnings
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
@@ -100,6 +101,14 @@ def get_tools(
             continue
 
         adapter = adapter_cls(spec, ctx)
-        results.append(adapter.to_tool())
+        try:
+            results.append(adapter.to_tool())
+        except Exception as exc:  # noqa: BLE001 - one bad tool must not sink the list
+            warnings.warn(
+                f"Skipping tool {spec.name!r}: failed to convert for framework "
+                f"{framework!r}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     return results

--- a/src/glean/agent_toolkit/adapters/openai.py
+++ b/src/glean/agent_toolkit/adapters/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import functools
 import json
 from collections.abc import Callable
@@ -46,6 +47,23 @@ except ImportError:  # pragma: no cover
 
 
 OpenAIFunctionTool: TypeAlias = _RealOpenAIFunctionTool | _FallbackOpenAIFunctionTool
+
+
+def _sanitize_schema_for_strict_mode(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a strict-mode-compatible copy of *schema*.
+
+    Uses the OpenAI Agents SDK's own ``ensure_strict_json_schema`` helper when
+    available. Raises if the schema cannot be made strict-compatible (e.g.
+    free-form ``object`` schemas with ``additionalProperties: true``), in which
+    case callers should fall back to non-strict mode.
+    """
+    schema_copy = copy.deepcopy(schema)
+    try:
+        from agents.strict_schema import ensure_strict_json_schema  # type: ignore
+    except ImportError:  # pragma: no cover - older/newer SDK layouts
+        return schema_copy
+    # NOTE: ensure_strict_json_schema mutates its input, hence the deepcopy.
+    return ensure_strict_json_schema(schema_copy)
 
 
 OpenAIToolType = dict[str, Any] | OpenAIFunctionTool
@@ -155,13 +173,23 @@ class OpenAIAdapter(BaseAdapter[OpenAIToolType]):
             else {"type": "object", "properties": {}}
         )
 
-        return _RuntimeOpenAIFunctionTool(
-            name=self.tool_spec.name,
-            description=self.tool_spec.description,
-            params_json_schema=params_json_schema_dict,
-            on_invoke_tool=on_invoke_tool,
-            strict_json_schema=True,
-        )
+        def _build_tool(schema: dict[str, Any], strict: bool) -> OpenAIFunctionTool:
+            return _RuntimeOpenAIFunctionTool(
+                name=self.tool_spec.name,
+                description=self.tool_spec.description,
+                params_json_schema=schema,
+                on_invoke_tool=on_invoke_tool,
+                strict_json_schema=strict,
+            )
+
+        try:
+            strict_schema = _sanitize_schema_for_strict_mode(params_json_schema_dict)
+            return _build_tool(strict_schema, strict=True)
+        except Exception:
+            # Schemas that cannot be expressed under OpenAI strict-mode rules
+            # (e.g. free-form dict parameters) fall back to non-strict mode so
+            # the tool still works instead of raising at construction time.
+            return _build_tool(copy.deepcopy(params_json_schema_dict), strict=False)
 
     def to_callable(self) -> Callable:
         """Get the callable for OpenAI function calling.

--- a/tests/test_openai_invocation.py
+++ b/tests/test_openai_invocation.py
@@ -1,0 +1,160 @@
+"""Regression tests for OpenAI Agents SDK strict-schema handling.
+
+These tests exercise the real ``openai-agents`` package (no stubbing of the
+SDK) to guarantee that:
+
+1. ``get_tools("openai")`` returns every built-in tool even though some tool
+   schemas (e.g. ``glean_search``'s free-form ``filters: list[dict]``) cannot
+   be expressed under OpenAI strict-mode rules.
+2. Tools whose schemas violate strict mode fall back cleanly to
+   ``strict_json_schema=False`` instead of raising ``UserError`` at
+   construction time.
+3. Tool invocation through the framework path (``on_invoke_tool``) works.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("agents")
+
+from agents.exceptions import UserError  # noqa: E402
+from agents.strict_schema import ensure_strict_json_schema  # noqa: E402
+from agents.tool import FunctionTool  # noqa: E402
+
+from glean.agent_toolkit import get_tools  # noqa: E402
+from glean.agent_toolkit.tools._common import make_ok  # noqa: E402
+
+EXPECTED_TOOL_NAMES = {
+    "glean_search",
+    "glean_web_search",
+    "glean_calendar_search",
+    "glean_employee_search",
+    "glean_code_search",
+    "glean_gmail_search",
+    "glean_outlook_search",
+    "glean_read_document",
+    "glean_chat",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+def _is_strict_valid(schema: dict[str, Any]) -> bool:
+    """Whether *schema* already satisfies OpenAI strict-mode rules."""
+    try:
+        ensure_strict_json_schema(copy.deepcopy(schema))
+    except UserError:
+        return False
+    return True
+
+
+def test_get_tools_openai_returns_all_builtin_tools() -> None:
+    """Regression: one strict-incompatible schema must not sink the whole list."""
+    tools = get_tools("openai", client=_mock_client())
+
+    names = {t.name for t in tools}
+    # Other test modules may register extra tools in the global registry, so
+    # assert the built-ins are a subset rather than an exact match.
+    assert EXPECTED_TOOL_NAMES <= names
+    for t in tools:
+        assert isinstance(t, FunctionTool)
+
+
+def test_search_as_openai_tool_constructs() -> None:
+    """Regression: glean_search previously raised UserError at construction."""
+    from glean.agent_toolkit.tools.search import search
+
+    tool = search.as_openai_tool()
+
+    assert isinstance(tool, FunctionTool)
+    assert tool.name == "glean_search"
+    if tool.strict_json_schema:
+        # If the tool claims strict mode, its schema must actually be
+        # strict-valid.
+        assert _is_strict_valid(tool.params_json_schema)
+    else:
+        # Clean fallback: the original (non-strict) schema is preserved,
+        # including the free-form filters dict.
+        filters_items = tool.params_json_schema["properties"]["filters"]["anyOf"][0]["items"]
+        assert filters_items == {"additionalProperties": True, "type": "object"}
+
+
+async def test_on_invoke_tool_framework_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drive a tool through the Agents SDK invocation path with Glean mocked."""
+    canned = make_ok({"documents": [{"title": "canned-doc"}]})
+    captured: dict[str, Any] = {}
+
+    def fake_run_tool(tool_display_name: str, parameters: Any, *, client: Any = None) -> Any:
+        captured["tool_display_name"] = tool_display_name
+        captured["parameters"] = parameters
+        return canned
+
+    import importlib
+
+    search_module = importlib.import_module("glean.agent_toolkit.tools.search")
+    monkeypatch.setattr(search_module, "run_tool", fake_run_tool)
+
+    tools = get_tools("openai", include=["glean_search"], client=_mock_client())
+    assert len(tools) == 1
+    tool = tools[0]
+
+    ctx_stub = MagicMock()  # the adapter ignores the SDK run context
+    result_str = await tool.on_invoke_tool(ctx_stub, '{"query": "test"}')
+
+    result = json.loads(result_str)
+    assert result["status"] == "ok"
+    assert result["result"] == {"documents": [{"title": "canned-doc"}]}
+    assert captured["tool_display_name"] == "Glean Search"
+
+
+def test_read_document_optional_params_schema_valid() -> None:
+    """Optional-params tool constructs and stays valid under strict mode."""
+    tools = get_tools("openai", include=["glean_read_document"], client=_mock_client())
+    assert len(tools) == 1
+    tool = tools[0]
+
+    assert isinstance(tool, FunctionTool)
+    schema = tool.params_json_schema
+    assert schema["type"] == "object"
+    if tool.strict_json_schema:
+        assert _is_strict_valid(schema)
+        # Strict mode forces optional params into `required`, but they must
+        # remain nullable so callers can still omit meaningful values.
+        assert set(schema["required"]) == {"document_id", "url"}
+        for prop in ("document_id", "url"):
+            any_of = schema["properties"][prop]["anyOf"]
+            assert {"type": "null"} in any_of
+
+
+def test_get_tools_warns_and_skips_on_conversion_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool that fails conversion entirely is skipped with a warning."""
+    from glean.agent_toolkit.adapters.openai import OpenAIAdapter
+
+    original_to_tool = OpenAIAdapter.to_tool
+
+    def flaky_to_tool(self: OpenAIAdapter) -> Any:
+        if self.tool_spec.name == "glean_chat":
+            raise RuntimeError("boom")
+        return original_to_tool(self)
+
+    monkeypatch.setattr(OpenAIAdapter, "to_tool", flaky_to_tool)
+
+    with pytest.warns(RuntimeWarning, match="glean_chat"):
+        tools = get_tools("openai", client=_mock_client())
+
+    names = {t.name for t in tools}
+    assert EXPECTED_TOOL_NAMES - {"glean_chat"} <= names
+    assert "glean_chat" not in names


### PR DESCRIPTION
## Problem

`get_tools("openai")` raised `agents.exceptions.UserError: additionalProperties should not be set for object types` and returned **zero tools** (reproduced on openai-agents 0.3.3).

Root cause: the OpenAI adapter constructs `FunctionTool` with `strict_json_schema=True` unconditionally. `glean_search`'s `filters: list[dict]` parameter generates an object schema with `additionalProperties: true`, which violates OpenAI strict-mode rules and raises at construction time. Since `get_tools()` builds all tools eagerly, one bad schema destroyed the entire tool list.

## Fix

- **Adapter (`adapters/openai.py`)**: pre-sanitize the input schema with the SDK's own `agents.strict_schema.ensure_strict_json_schema` (on a deepcopy — it mutates its input, and `ToolSpec.input_schema` is shared) and construct with `strict_json_schema=True`. If the schema cannot be expressed under strict-mode rules, fall back to `strict_json_schema=False` for that tool so conversion never raises. Free-form dict semantics are preserved in the fallback rather than silently coerced to `additionalProperties: false` (which would reject every key).
- **`get_tools()` (`__init__.py`)**: a per-tool conversion failure now emits a `RuntimeWarning` naming the tool and skips it, instead of sinking the whole list. Framework-dependency `ImportError`s still propagate as documented.

## Result

- All 9 built-in tools convert: 8 remain strict (optional params become required nullable unions, per strict-mode rules), `glean_search` cleanly falls back to non-strict.
- New regression tests (`tests/test_openai_invocation.py`) run against the real `openai-agents` package: full tool-list construction, strict/fallback assertions, driving `on_invoke_tool` through the framework path with the Glean layer mocked, and optional-param schema validity. 4 of 5 fail on the unfixed code (verified via stash).
- Full suite: 163 passed, 4 skipped. ruff + pyright clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)