### PR TITLE
fix(adk): expose real typed signatures so declarations and invocation work

### DIFF
--- a/src/glean/agent_toolkit/adapters/adk.py
+++ b/src/glean/agent_toolkit/adapters/adk.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import functools
+import inspect
+import types
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, Union, get_args, get_origin
 
 from glean.agent_toolkit.adapters.base import BaseAdapter
 from glean.agent_toolkit.spec import ToolSpec
@@ -24,22 +25,20 @@ class _FallbackAdkFunctionTool:
     """Fallback for google.adk.tools.FunctionTool.
 
     This lightweight stand-in mimics the public attributes accessed by tests
-    (``name``, ``description``, ``schema`` and ``func``). It purposefully keeps
-    the same runtime surface as the real ADK ``FunctionTool`` so that unit
-    tests exercising the adapter behave consistently even when the dependency
-    is missing.
+    (``name``, ``description`` and ``func``). It purposefully keeps the same
+    runtime surface as the real ADK ``FunctionTool`` so that unit tests
+    exercising the adapter behave consistently even when the dependency is
+    missing.
     """
 
     name: str
     description: str | None
     func: Callable[..., Any]
-    schema: dict[str, Any] | None
 
     def __init__(self, func: Callable[..., Any]) -> None:  # noqa: ANN101, D401
         self.func = func
         self.name = func.__name__
         self.description = func.__doc__
-        self.schema = None  # Set later by the adapter
 
 
 try:
@@ -52,6 +51,66 @@ except ImportError:  # pragma: no cover
 
 # Single alias used for typing and at runtime
 AdkFunctionTool: TypeAlias = _RealAdkFunctionTool | _FallbackAdkFunctionTool
+
+_JSON_TYPE_TO_ANNOTATION: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+    "null": type(None),
+}
+
+
+def _annotation_from_json_schema(prop_schema: dict[str, Any]) -> Any:
+    """Map a JSON-schema property to a Python type annotation.
+
+    ADK derives function declarations exclusively from the wrapper's
+    signature, so the JSON schema stored on the ToolSpec must be translated
+    back into real Python annotations.
+
+    Args:
+        prop_schema: JSON schema for a single property.
+
+    Returns:
+        A Python type annotation suitable for a function signature.
+    """
+    if "anyOf" in prop_schema:
+        members = [
+            _annotation_from_json_schema(sub)
+            for sub in prop_schema["anyOf"]
+            if isinstance(sub, dict)
+        ]
+        if not members:
+            return Any
+        annotation = members[0]
+        for member in members[1:]:
+            annotation = annotation | member
+        return annotation
+
+    json_type = prop_schema.get("type")
+    if json_type == "array":
+        items = prop_schema.get("items")
+        if isinstance(items, dict):
+            item_annotation = _annotation_from_json_schema(items)
+            if item_annotation is not Any:
+                return list[item_annotation]
+        return list
+    if json_type == "object":
+        return dict[str, Any]
+    if not isinstance(json_type, str):
+        return Any
+    return _JSON_TYPE_TO_ANNOTATION.get(json_type, Any)
+
+
+def _is_optional_annotation(annotation: Any) -> bool:
+    """Return ``True`` if *annotation* already permits ``None``."""
+    if annotation is Any or annotation is type(None):
+        return True
+    if isinstance(annotation, types.UnionType) or get_origin(annotation) is Union:
+        return type(None) in get_args(annotation)
+    return False
 
 
 class ADKAdapter(BaseAdapter["AdkFunctionTool"]):
@@ -72,33 +131,132 @@ class ADKAdapter(BaseAdapter["AdkFunctionTool"]):
                 "`pip install google-adk`."
             )
 
+    def _build_parameters(self) -> list[inspect.Parameter]:
+        """Build explicit signature parameters from the tool's input schema.
+
+        Returns:
+            Ordered ``inspect.Parameter`` list (required parameters first).
+        """
+        schema = self.tool_spec.input_schema or {}
+        properties: dict[str, Any] = schema.get("properties") or {}
+        required = set(schema.get("required") or ())
+
+        parameters: list[inspect.Parameter] = []
+        for prop_name, prop_schema in properties.items():
+            prop_schema = prop_schema if isinstance(prop_schema, dict) else {}
+            annotation = _annotation_from_json_schema(prop_schema)
+            if prop_name in required:
+                default: Any = inspect.Parameter.empty
+            else:
+                default = prop_schema.get("default")
+                if default is None and not _is_optional_annotation(annotation):
+                    annotation = annotation | None
+            parameters.append(
+                inspect.Parameter(
+                    prop_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=default,
+                    annotation=annotation,
+                )
+            )
+
+        # Required parameters must precede optional ones in a valid signature.
+        parameters.sort(key=lambda param: param.default is not inspect.Parameter.empty)
+        return parameters
+
+    def _find_context_param_name(self) -> str | None:
+        """Find the name of the underlying function's context parameter.
+
+        The decorator excludes ``GleanContext`` parameters from the input
+        schema, so any signature parameter absent from the schema properties
+        is the context parameter.
+
+        Returns:
+            The context parameter name, or ``None`` if the function does not
+            accept a context.
+        """
+        schema = self.tool_spec.input_schema or {}
+        properties: dict[str, Any] = schema.get("properties") or {}
+        try:
+            signature = inspect.signature(self.tool_spec.function)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+        for param_name, param in signature.parameters.items():
+            if param.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+            if param_name not in properties:
+                return param_name
+        return None
+
+    def _build_adk_function(self) -> Callable[..., Any]:
+        """Build a wrapper with a real, explicit signature for ADK.
+
+        ADK builds function declarations from ``inspect.signature`` and
+        invokes tools with keyword arguments, so the wrapper exposes the
+        schema-derived parameters directly and binds the Glean context (when
+        present) inside the closure.
+
+        Returns:
+            An async wrapper function (sync if no async implementation
+            exists) whose signature mirrors the tool's input schema.
+        """
+        tool_spec = self.tool_spec
+        parameters = self._build_parameters()
+        signature = inspect.Signature(parameters)
+
+        bound_kwargs: dict[str, Any] = {}
+        if self.ctx is not None:
+            ctx_param_name = self._find_context_param_name()
+            if ctx_param_name is not None:
+                bound_kwargs[ctx_param_name] = self.ctx
+
+        async_func = tool_spec.async_function
+        sync_func = tool_spec.function
+
+        def _to_kwargs(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+            call_kwargs = dict(bound_kwargs)
+            for value, parameter in zip(args, parameters, strict=False):
+                call_kwargs[parameter.name] = value
+            call_kwargs.update(kwargs)
+            return call_kwargs
+
+        wrapper: Callable[..., Any]
+        if async_func is not None:
+
+            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await async_func(**_to_kwargs(args, kwargs))
+
+            wrapper = _async_wrapper
+        else:
+
+            def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return sync_func(**_to_kwargs(args, kwargs))
+
+            wrapper = _sync_wrapper
+
+        wrapper.__name__ = tool_spec.name
+        wrapper.__qualname__ = tool_spec.name
+        wrapper.__doc__ = tool_spec.description
+        wrapper.__signature__ = signature  # type: ignore[attr-defined]
+        wrapper.__annotations__ = {parameter.name: parameter.annotation for parameter in parameters}
+        return wrapper
+
     def to_tool(self) -> AdkFunctionTool:
         """Convert to Google ADK FunctionTool format.
 
-        Uses the async function when available since ADK natively
-        supports async tool functions.
+        Builds an async wrapper whose signature is derived from the tool's
+        input schema so that ADK's function declaration exposes real, typed
+        parameters and ``run_async`` forwards arguments correctly.
 
         Returns:
             An ADK FunctionTool instance
         """
-        async_func = self.tool_spec.async_function
-        sync_func = self.tool_spec.function
-
-        if async_func is not None:
-            func = async_func
-            if self.ctx is not None:
-                func = functools.partial(func, self.ctx)
-        else:
-            func = sync_func
-            if self.ctx is not None:
-                func = functools.partial(func, self.ctx)
-
-        if not func.__doc__:
-            func.__doc__ = self.tool_spec.description
+        func = self._build_adk_function()
 
         tool = _RuntimeAdkFunctionTool(func=func)  # type: ignore[arg-type]
-
         tool.name = self.tool_spec.name
-        setattr(tool, "schema", self.tool_spec.input_schema)
 
         return tool

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -138,9 +138,11 @@ def test_adk_adapter_integration() -> None:
     assert getattr(tool, "name", "") == "add"
     assert "Add two integers" in getattr(tool, "description", "")
 
-    # Test the tool can be used
+    # Test the tool can be used and exposes a real, typed signature
     assert callable(getattr(tool, "func", lambda: None))
-    assert hasattr(tool, "schema")
+    import inspect
+
+    assert list(inspect.signature(tool.func).parameters) == ["a", "b"]
 
 
 @pytest.mark.skipif(not HAS_ADK, reason="Google ADK not installed")

--- a/tests/test_adk_invocation.py
+++ b/tests/test_adk_invocation.py
@@ -1,0 +1,153 @@
+"""Regression tests for ADK tool declarations and invocation.
+
+These tests exercise the real ``google-adk`` package. They cover a
+regression where the ADK adapter wrapped tool functions in
+``functools.partial`` (breaking ``_get_declaration`` with an
+``AttributeError``) and exposed a bare ``(*args, **kwargs)`` signature
+(so declarations contained zero typed parameters and ``run_async``
+dropped all arguments).
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Generator
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from glean.agent_toolkit.registry import get_registry
+
+try:
+    from glean.agent_toolkit.adapters.adk import HAS_ADK
+except ImportError:  # pragma: no cover
+    HAS_ADK = False
+
+pytestmark = pytest.mark.skipif(not HAS_ADK, reason="Google ADK not installed")
+
+
+def _mock_client() -> mock.MagicMock:
+    client = mock.MagicMock()
+    client.__enter__ = mock.MagicMock(return_value=client)
+    client.__exit__ = mock.MagicMock(return_value=False)
+    return client
+
+
+def _declaration_properties(tool: Any) -> dict[str, Any]:
+    """Return the declared parameter properties for an ADK tool."""
+    declaration = tool._get_declaration()
+    assert declaration is not None
+    assert declaration.parameters is not None
+    return declaration.parameters.properties or {}
+
+
+@pytest.fixture
+def unregister_tools() -> Generator[list[str], None, None]:
+    """Track tool names registered by a test and remove them afterwards."""
+    names: list[str] = []
+    yield names
+    registry = get_registry()
+    for name in names:
+        registry._tools.pop(name, None)
+
+
+def test_get_tools_adk_declarations_expose_parameters() -> None:
+    """get_tools("adk") tools must expose typed declarations (ctx is bound)."""
+    from glean.agent_toolkit import get_tools
+
+    tools = get_tools("adk", client=_mock_client())
+    assert tools
+
+    by_name = {tool.name: tool for tool in tools}
+    assert "glean_search" in by_name
+
+    # Previously raised AttributeError: 'functools.partial' object has no
+    # attribute '__name__'.
+    properties = _declaration_properties(by_name["glean_search"])
+    assert "query" in properties
+    assert "page_size" in properties
+
+    declaration = by_name["glean_search"]._get_declaration()
+    assert declaration.parameters.required == ["query"]
+
+    # Every adapted tool must declare its schema parameters, not zero params.
+    for name, tool in by_name.items():
+        spec = get_registry().get(name)
+        assert spec is not None
+        expected = set((spec.input_schema.get("properties") or {}).keys())
+        assert set(_declaration_properties(tool).keys()) == expected
+
+
+async def test_run_async_delivers_arguments_to_search() -> None:
+    """run_async must forward LLM-provided args to the underlying function."""
+    from glean.agent_toolkit import get_tools
+
+    search_mod = importlib.import_module("glean.agent_toolkit.tools.search")
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_tool(
+        tool_display_name: str,
+        parameters: dict[str, Any],
+        *,
+        client: Any = None,
+    ) -> dict[str, Any]:
+        captured["tool_display_name"] = tool_display_name
+        captured["parameters"] = {key: value.value for key, value in parameters.items()}
+        return {"status": "success", "result": "canned-result"}
+
+    with mock.patch.object(search_mod, "run_tool", fake_run_tool):
+        (tool,) = get_tools("adk", include=["glean_search"], client=_mock_client())
+        result = await tool.run_async(
+            args={"query": "test", "page_size": 5},
+            tool_context=None,
+        )
+
+    assert result == {"status": "success", "result": "canned-result"}
+    assert captured["tool_display_name"] == "Glean Search"
+    # Previously the (*args, **kwargs) wrapper signature made ADK drop every
+    # argument, so the query never reached the tool implementation.
+    assert captured["parameters"]["query"] == "test"
+    assert captured["parameters"]["pageSize"] == "5"
+
+
+async def test_custom_multi_arg_tool_via_adk(unregister_tools: list[str]) -> None:
+    """A custom multi-argument tool must declare and receive its arguments."""
+    from glean.agent_toolkit import tool_spec
+
+    @tool_spec(name="adk_invocation_test_add", description="Add two integers")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    unregister_tools.append("adk_invocation_test_add")
+
+    tool = add.as_adk_tool()
+
+    properties = _declaration_properties(tool)
+    assert set(properties.keys()) == {"a", "b"}
+    assert set(tool._get_declaration().parameters.required) == {"a", "b"}
+
+    result = await tool.run_async(args={"a": 3, "b": 5}, tool_context=None)
+    assert result == 8
+
+
+async def test_custom_tool_via_get_tools_with_bound_context(
+    unregister_tools: list[str],
+) -> None:
+    """Binding a GleanContext must not leak into tools that do not accept one."""
+    from glean.agent_toolkit import get_tools, tool_spec
+
+    @tool_spec(name="adk_invocation_test_add_ctx", description="Add two integers")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    unregister_tools.append("adk_invocation_test_add_ctx")
+
+    (tool,) = get_tools(
+        "adk",
+        include=["adk_invocation_test_add_ctx"],
+        client=_mock_client(),
+    )
+    result = await tool.run_async(args={"a": 3, "b": 5}, tool_context=None)
+    assert result == 8


### PR DESCRIPTION
## Problem

Empirically reproduced on google-adk 1.36.1: the ADK adapter's `to_tool()` was broken on every path.

1. **Crash on the documented path.** `get_tools("adk")` always binds a `GleanContext`, and the adapter bound it via `functools.partial`. `functools.partial` has no `__name__`, so ADK's `_get_declaration()` raised `AttributeError: 'functools.partial' object has no attribute '__name__'` and the agent crashed before the first model call.
2. **Zero typed parameters without ctx.** The decorator's async wrapper has a bare `(*args, **kwargs)` signature. ADK derives function declarations exclusively from `inspect.signature`, so the LLM saw a tool with no parameters and `run_async` filtered out (dropped) every argument the model supplied.
3. **Dead code.** The `.schema` attribute set on the tool is never read by ADK.

## Fix (confined to `adapters/adk.py`)

`to_tool()` now builds an async wrapper (sync fallback when no async implementation exists) with a **real explicit signature** derived from `tool_spec.input_schema`:

- JSON-schema types are mapped to Python annotations (`str`/`int`/`float`/`bool`/`list[...]`/`dict[str, Any]`, `anyOf` unions, optionals as `X | None` with schema defaults), and `__signature__`, `__annotations__`, `__name__`, `__qualname__`, `__doc__` are set so ADK's declaration builder and `run_async` argument filtering both see the true parameters.
- The `GleanContext` is bound **inside the wrapper closure** (never via `functools.partial`), by keyword, and only when the underlying function actually accepts a context parameter — so custom tools like `add(a, b)` also work through `get_tools()`.
- Removed the dead `.schema` assignment (and updated the one test that asserted it).

## Verification

- New `tests/test_adk_invocation.py` runs against **real google-adk**: declaration for `glean_search` lists `query`/`page_size` with `required=["query"]` (and every adapted tool's declaration matches its input schema); `await tool.run_async(args={"query": "test", "page_size": 5}, tool_context=None)` with the Glean layer monkeypatched returns the canned result and the query reaches the implementation; custom multi-arg `add(a, b)` returns 8, with and without a bound context.
- Sanity-checked: all four new tests **fail on the previous implementation** (first with the exact `AttributeError`, the rest with dropped/missing arguments).
- `mise run test`: 162 passed, 4 skipped. `mise run lint:diff`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)