### PR TITLE
ci: add test-only install check, coverage gate, and nightly latest-frameworks matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,44 @@ jobs:
       - name: Run tests
         run: mise run test
 
+      # Coverage gate runs on a single matrix leg to keep the signal in one
+      # place. The threshold is set ~2 points below measured coverage so it
+      # catches regressions without flaking on noise.
+      - name: Run tests with coverage gate
+        if: matrix.python-version == '3.13'
+        run: uv run pytest --cov=glean --cov-report=term --cov-fail-under=66 tests/
+
       - name: Test package installation
         run: |
           mise run build
           uv run pip install dist/*.whl
           uv run python -c "import glean.agent_toolkit; print('Package installed successfully')"
+
+  # Guards installs that only pull the `test` extra (no dev extras). A conftest
+  # import bug once broke `pip install -e ".[test]"` consumers for months
+  # because CI always installed the full dev environment and never noticed.
+  test-only-install:
+    name: Test-only install (.[test])
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install with test extra only
+        run: |
+          uv venv .venv
+          uv pip install -e ".[test]"
+
+      # Invoke the venv's python directly (not `uv run`, which can sync extra
+      # project dependencies into the environment and mask missing test deps).
+      - name: Verify test collection
+        run: .venv/bin/python -m pytest tests/ --collect-only -q
+
+      - name: Run tests
+        run: .venv/bin/python -m pytest -v --tb=auto -rA tests/

--- a/.github/workflows/nightly-frameworks.yml
+++ b/.github/workflows/nightly-frameworks.yml
@@ -1,0 +1,48 @@
+name: Nightly Latest Frameworks
+
+# Runs the full test suite against the LATEST released version of each agent
+# framework we adapt to. The PR-gating CI job pins framework versions via the
+# locked dev environment, so a breaking framework release (this happened with
+# LangChain) would otherwise go undetected until a user hit it. One matrix leg
+# per framework so a breaking release is directly attributable. A failed run
+# is the alert; there are no external notifications.
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  latest-frameworks:
+    name: Latest ${{ matrix.framework }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework:
+          - langchain-core
+          - openai-agents
+          - google-adk
+          - crewai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup development environment (locked deps)
+        run: mise run setup
+
+      - name: Upgrade ${{ matrix.framework }} to latest release
+        run: uv pip install --upgrade ${{ matrix.framework }}
+
+      - name: Show resolved framework version
+        run: uv pip show ${{ matrix.framework }}
+
+      - name: Run full test suite
+        run: uv run pytest -v --tb=auto -rA tests/

--- a/mise.toml
+++ b/mise.toml
@@ -34,6 +34,26 @@ run = "uv run ptw --now . -- -vv --tb=auto -rA --durations=10 -p no:logging test
 description = "Run tests with coverage"
 run = "uv run pytest --cov=glean --cov-report=term --cov-report=html -v tests/"
 
+[tasks."test:latest-frameworks"]
+description = "Upgrade all agent frameworks to their latest releases and run the full suite (mirrors nightly CI; note CI upgrades one framework per matrix leg)"
+run = [
+  "uv pip install --upgrade langchain-core openai-agents google-adk crewai",
+  "uv run pytest -v --tb=auto -rA -p no:logging tests/",
+]
+
+[tasks."test:install-only"]
+description = "Verify the package tests pass with only the [test] extra installed (mirrors the CI test-only-install job) — uses a throwaway venv"
+shell = "bash -c"
+run = """
+set -euo pipefail
+VENV_ROOT=$(mktemp -d)
+trap 'rm -rf "$VENV_ROOT"' EXIT
+uv venv "$VENV_ROOT/venv" --python "$(command -v python)"
+VIRTUAL_ENV="$VENV_ROOT/venv" uv pip install -e ".[test]"
+"$VENV_ROOT/venv/bin/python" -m pytest tests/ --collect-only -q
+"$VENV_ROOT/venv/bin/python" -m pytest -v --tb=auto -rA tests/
+"""
+
 [tasks."test:vcr:regenerate"]
 description = "Regenerate all VCR cassettes by re-recording HTTP interactions"
 run = [


### PR DESCRIPTION
## Summary

Hardens CI against three failure modes a design review flagged: framework releases silently breaking adapters, test-only installs breaking undetected, and coverage regressions.

## Changes

### `ci.yml`: `test-only-install` job
Installs the package with **only** `pip install -e ".[test]"` (no dev extras) into a fresh venv, then runs pytest collection and the full suite, invoking the venv's python directly (not `uv run`, which can sync extra project deps into the environment and mask missing test deps). A conftest import bug previously broke `.[test]`-only installs for months because CI always installed the full dev environment. Verified locally on current main: 193 passed, 4 skipped.

### `ci.yml`: coverage gate
On the Python 3.13 matrix leg, runs `uv run pytest --cov=glean --cov-report=term --cov-fail-under=66`. Measured coverage today is **68.29%**; the gate is set ~2 points below so it catches regressions without immediately breaking CI. The existing locked-deps Python 3.10-3.13 matrix remains the required PR gate, unchanged.

### New `nightly-frameworks.yml`
Scheduled (`23 6 * * *`) + `workflow_dispatch`. Four matrix legs (`fail-fast: false`), one per framework: `langchain-core`, `openai-agents`, `google-adk`, `crewai`. Each leg installs the repo's locked dev environment (`mise run setup`), force-upgrades **one** framework to its latest release (`uv pip install --upgrade <framework>`), prints the resolved version, and runs the full test suite (which includes real-framework invocation tests). One framework per leg means a breaking upstream release is directly attributable to a single red leg. A failed run is the alert -- no external notifications. This is exactly the gap that let a breaking LangChain release reach production undetected.

### `mise.toml` tasks (local mirrors; workflows are self-sufficient)
- `test:latest-frameworks`: upgrades all four frameworks to latest and runs the suite.
- `test:install-only`: builds a throwaway venv with only `.[test]` and runs collection + suite.

## Verification
- Baseline suite green after `mise run setup` (193 passed, 4 skipped).
- `.[test]`-only install verified from a clean venv on current main: install, collection, and suite all pass.
- Coverage gate command dry-run locally: `Required test coverage of 66% reached. Total coverage: 68.29%`.
- Nightly leg dry-run locally: upgraded `langchain-core` to latest (1.4.9) in the test-only venv; suite still green.
- All workflow YAML parses (`yaml.safe_load`); `mise tasks ls` parses the new tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)