### PR TITLE
fix(read_document): support renamed retrieve kwarg across glean-api-client versions

### DIFF
--- a/src/glean/agent_toolkit/tools/_compat.py
+++ b/src/glean/agent_toolkit/tools/_compat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import warnings
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
@@ -39,6 +40,54 @@ def resolve_method(obj: Any, preferred: str, *fallbacks: str) -> Any:
 
     tried = ", ".join([preferred, *fallbacks])
     raise AttributeError(f"{type(obj).__name__} has none of the expected methods: {tried}")
+
+
+def resolve_kwarg(fn: Any, preferred: str, *fallbacks: str) -> str:
+    """Return the first keyword argument name accepted by *fn*.
+
+    Inspects the callable's signature to pick the keyword argument to use,
+    warning when a fallback (legacy) name is selected. If the signature
+    cannot be introspected, or the callable accepts arbitrary ``**kwargs``,
+    *preferred* is returned.
+
+    Args:
+        fn: The callable whose signature to inspect.
+        preferred: The preferred keyword argument name.
+        *fallbacks: Alternative keyword argument names to try in order.
+
+    Returns:
+        The keyword argument name to use when calling *fn*.
+
+    Raises:
+        TypeError: If *fn* accepts neither *preferred*, any fallback, nor
+            arbitrary ``**kwargs``.
+    """
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return preferred
+
+    if preferred in params:
+        return preferred
+
+    fn_name = getattr(fn, "__qualname__", None) or getattr(fn, "__name__", None) or repr(fn)
+
+    for name in fallbacks:
+        if name in params:
+            warnings.warn(
+                f"{fn_name}() does not accept keyword argument '{preferred}'; "
+                f"falling back to '{name}'. "
+                f"This fallback will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return name
+
+    if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        return preferred
+
+    tried = ", ".join([preferred, *fallbacks])
+    raise TypeError(f"{fn_name} accepts none of the expected keyword arguments: {tried}")
 
 
 def get_api_client_version() -> str | None:

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -86,10 +86,13 @@ def read_document(
                 include_fields=include_fields,
             )
 
-        from glean.agent_toolkit.tools._compat import resolve_method
+        from glean.agent_toolkit.tools._compat import resolve_kwarg, resolve_method
 
         retrieve_fn = resolve_method(documents_client, "retrieve", "get")
-        result = retrieve_fn(request=request)
+        # glean-api-client renamed the kwarg from `request` (<=0.6.x) to
+        # `get_documents_request` (>=0.15.x).
+        request_kwarg = resolve_kwarg(retrieve_fn, "get_documents_request", "request")
+        result = retrieve_fn(**{request_kwarg: request})
 
         return common.serialize_tool_result(result)
 

--- a/tests/tools/test_api_compat.py
+++ b/tests/tools/test_api_compat.py
@@ -7,6 +7,7 @@ import pytest
 from glean.agent_toolkit.tools._compat import (
     check_api_client_compatibility,
     get_api_client_version,
+    resolve_kwarg,
     resolve_method,
 )
 
@@ -52,6 +53,54 @@ def test_resolve_method_no_fallbacks() -> None:
     obj = _EmptyClient()
     with pytest.raises(AttributeError):
         resolve_method(obj, "run")
+
+
+def _new_style(*, get_documents_request: object) -> str:
+    return "new"
+
+
+def _old_style(*, request: object) -> str:
+    return "old"
+
+
+def _kwargs_only(**kwargs: object) -> str:
+    return "kwargs"
+
+
+def _no_match(*, other: object) -> str:
+    return "other"
+
+
+def test_resolve_kwarg_preferred() -> None:
+    assert resolve_kwarg(_new_style, "get_documents_request", "request") == (
+        "get_documents_request"
+    )
+
+
+def test_resolve_kwarg_fallback_with_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        name = resolve_kwarg(_old_style, "get_documents_request", "request")
+        assert name == "request"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "falling back to 'request'" in str(w[0].message)
+
+
+def test_resolve_kwarg_var_keyword_uses_preferred() -> None:
+    assert resolve_kwarg(_kwargs_only, "get_documents_request", "request") == (
+        "get_documents_request"
+    )
+
+
+def test_resolve_kwarg_none_found() -> None:
+    with pytest.raises(TypeError, match="accepts none of the expected keyword arguments"):
+        resolve_kwarg(_no_match, "get_documents_request", "request")
+
+
+def test_resolve_kwarg_uninspectable_uses_preferred() -> None:
+    # Some C-implemented callables cannot be introspected via inspect.signature.
+    assert resolve_kwarg(min, "get_documents_request", "request") == "get_documents_request"
 
 
 def test_get_api_client_version_returns_string() -> None:

--- a/tests/tools/test_read_document.py
+++ b/tests/tools/test_read_document.py
@@ -24,6 +24,12 @@ def _make_ctx(
     return GleanContext(client=mock_client)
 
 
+def _sent_request(mock_retrieve: MagicMock) -> object:
+    """Extract the request model regardless of which kwarg name was used."""
+    kwargs = mock_retrieve.call_args.kwargs
+    return kwargs.get("get_documents_request", kwargs.get("request"))
+
+
 def test_read_document_by_id_success() -> None:
     mock_result = {"content": {"text": "Hello world"}}
     ctx = _make_ctx(documents_return=mock_result)
@@ -36,7 +42,7 @@ def test_read_document_by_id_success() -> None:
 
     mock_client = ctx.get_client()
     mock_client.client.documents.retrieve.assert_called_once()  # type: ignore[union-attr]
-    sent = mock_client.client.documents.retrieve.call_args.kwargs["request"]  # type: ignore[union-attr]
+    sent = _sent_request(mock_client.client.documents.retrieve)  # type: ignore[union-attr,arg-type]
     assert isinstance(sent, models.GetDocumentsRequest)
     assert len(sent.document_specs) == 1
     assert isinstance(sent.document_specs[0], models.DocumentSpec2)
@@ -58,7 +64,7 @@ def test_read_document_by_url_success() -> None:
 
     mock_client = ctx.get_client()
     mock_client.client.documents.retrieve.assert_called_once()  # type: ignore[union-attr]
-    sent = mock_client.client.documents.retrieve.call_args.kwargs["request"]  # type: ignore[union-attr]
+    sent = _sent_request(mock_client.client.documents.retrieve)  # type: ignore[union-attr,arg-type]
     assert isinstance(sent, models.GetDocumentsRequest)
     assert len(sent.document_specs) == 1
     assert isinstance(sent.document_specs[0], models.DocumentSpec1)
@@ -105,3 +111,67 @@ def test_read_document_serializes_model_with_aliases() -> None:
     assert result["status"] == "ok"
     assert result.get("error") is None
     assert result["result"] == {"fullTextList": ["hello"]}
+
+
+class _NewStyleDocuments:
+    """Simulates glean-api-client >=0.15.x: retrieve(*, get_documents_request)."""
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    def retrieve(self, *, get_documents_request: object) -> object:
+        self.requests.append(get_documents_request)
+        return {"content": {"text": "new-style"}}
+
+
+class _OldStyleDocuments:
+    """Simulates glean-api-client 0.6.x: retrieve(*, request)."""
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    def retrieve(self, *, request: object) -> object:
+        self.requests.append(request)
+        return {"content": {"text": "old-style"}}
+
+
+def _make_ctx_with_documents(documents: object) -> GleanContext:
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.client.documents = documents
+    return GleanContext(client=mock_client)
+
+
+def test_read_document_new_sdk_kwarg() -> None:
+    """retrieve accepting only get_documents_request (>=0.15.x) must work."""
+    documents = _NewStyleDocuments()
+    ctx = _make_ctx_with_documents(documents)
+
+    result = read_document(ctx, document_id="glean_123")
+
+    assert result["status"] == "ok"
+    assert result["result"] == {"content": {"text": "new-style"}}
+    assert len(documents.requests) == 1
+    sent = documents.requests[0]
+    assert isinstance(sent, models.GetDocumentsRequest)
+    spec = sent.document_specs[0]
+    assert isinstance(spec, models.DocumentSpec2)
+    assert spec.id == "glean_123"
+
+
+def test_read_document_old_sdk_kwarg() -> None:
+    """retrieve accepting only request (0.6.x) must still work."""
+    documents = _OldStyleDocuments()
+    ctx = _make_ctx_with_documents(documents)
+
+    result = read_document(ctx, document_id="glean_123")
+
+    assert result["status"] == "ok"
+    assert result["result"] == {"content": {"text": "old-style"}}
+    assert len(documents.requests) == 1
+    sent = documents.requests[0]
+    assert isinstance(sent, models.GetDocumentsRequest)
+    spec = sent.document_specs[0]
+    assert isinstance(spec, models.DocumentSpec2)
+    assert spec.id == "glean_123"


### PR DESCRIPTION
## Problem

`glean-api-client` renamed the documents retrieve keyword argument:

- `<=0.6.x`: `ClientDocuments.retrieve(*, request=...)`
- `>=0.15.x`: `ClientDocuments.retrieve(*, get_documents_request=...)`

`read_document` calls `retrieve_fn(request=request)`, so on any newer SDK it raises `TypeError: ClientDocuments.retrieve() got an unexpected keyword argument 'request'`, which the error handler wraps into `{"status": "error", "error_type": "api"}`. Since `pyproject.toml` allows `glean-api-client >=0.6.0,<1.0` and a fresh resolution picks 0.15.3, **`read_document` is broken at runtime for every fresh install** — only the `uv.lock` dev environment (pinned to 0.6.0) is unaffected. The existing `resolve_method` shim in `_compat.py` handles method renames but not kwarg renames.

## Fix

- Add `resolve_kwarg(fn, preferred, *fallbacks)` to `src/glean/agent_toolkit/tools/_compat.py`: inspects `inspect.signature(fn).parameters` and returns the first accepted kwarg name, preferring the new name; emits a `DeprecationWarning` when falling back to a legacy name (mirroring `resolve_method`); returns the preferred name for `**kwargs`-only or uninspectable callables; raises `TypeError` if no candidate is accepted.
- `read_document` now uses it to call retrieve with `get_documents_request=` when available, else `request=`.

Intentionally out of scope (separate workstreams): SDK floor bump in `pyproject.toml`/`uv.lock`, and the `ChatMessage.citations` deprecation in `chat.py`.

## Tests

- New stub-client tests in `tests/tools/test_read_document.py`: one documents client whose `retrieve` accepts only `get_documents_request` (0.15.x semantics) and one accepting only `request` (0.6.x semantics) — `read_document` must succeed against both. The new-SDK test fails on the pre-fix code (`status == "error"` instead of `"ok"`), so the regression is covered under the locked env.
- Unit tests for `resolve_kwarg` in `tests/tools/test_api_compat.py` (preferred, fallback+warning, `**kwargs`-only, none-found, uninspectable callable).
- Existing `test_read_document.py` assertions updated to be kwarg-name-agnostic (the mocks accept `**kwargs`, so the preferred new name is now used).

## Verification

- **Locked env** (`uv.lock`, glean-api-client 0.6.0): `mise run test` — 200 passed, 4 skipped. `mise run lint` clean.
- **Fresh env** (fresh venv, `uv pip install -e ".[test]"` resolving glean-api-client **0.15.3**):
  - Pre-fix call style reproduces the bug: `TypeError: ClientDocuments.retrieve() got an unexpected keyword argument 'request'`.
  - With the fix: `tests/tools/test_read_document.py` + `tests/tools/test_api_compat.py` — 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)