### PR TITLE
chore(ci): tighten coverage gate to 90 and restore fractional retry docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       # catches regressions without flaking on noise.
       - name: Run tests with coverage gate
         if: matrix.python-version == '3.13'
-        run: uv run pytest --cov=glean --cov-report=term --cov-fail-under=66 tests/
+        run: uv run pytest --cov=glean --cov-report=term --cov-fail-under=90 tests/
 
       - name: Test package installation
         run: |

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and k
 
 | Variable                  | Default | Description                                              | Example |
 | ------------------------- | ------- | -------------------------------------------------------- | ------- |
-| `GLEAN_RETRY_INITIAL`     | `1`     | Initial backoff interval in seconds                      | `2`     |
-| `GLEAN_RETRY_MAX`         | `50`    | Maximum backoff interval in seconds                      | `8`     |
+| `GLEAN_RETRY_INITIAL`     | `1.0`   | Initial backoff interval in seconds                      | `0.5`   |
+| `GLEAN_RETRY_MAX`         | `50.0`  | Maximum backoff interval in seconds                      | `8`     |
 | `GLEAN_RETRY_MULTIPLIER`  | `1.1`   | Backoff multiplier/exponent                              | `2.0`   |
-| `GLEAN_RETRY_MAX_ELAPSED` | `60`    | Total time limit in seconds before giving up on retries  | `30`    |
+| `GLEAN_RETRY_MAX_ELAPSED` | `60.0`  | Total time limit in seconds before giving up on retries  | `30`    |
 
-Intervals are expressed in seconds; the multiplier is a unitless exponent. Retries cover transient failures such as HTTP 429/5xx and connection timeouts. Set these before constructing any Glean client usage.
+Intervals are expressed in seconds and may be fractional (e.g. `0.5`); the multiplier is a unitless exponent. Retries cover transient failures such as HTTP 429/5xx and connection timeouts. Set these before constructing any Glean client usage.
 
 ```bash
-# Example: bounded retries
-export GLEAN_RETRY_INITIAL=1
+# Example: low-latency, bounded retries
+export GLEAN_RETRY_INITIAL=0.5
 export GLEAN_RETRY_MAX=8
 export GLEAN_RETRY_MULTIPLIER=2.0
 export GLEAN_RETRY_MAX_ELAPSED=30


### PR DESCRIPTION
Two small follow-ups from the Wave 3 merges:

- **Coverage gate 66 → 90**: #82 scoped coverage measurement to the toolkit itself (excluding the co-namespaced `glean.api_client`), revealing the real baseline is ~92%. This tightens the gate to hold that line, per the note left on #82.
- **README retry docs**: restore the fractional-seconds example (`GLEAN_RETRY_INITIAL=0.5`) removed in #85 — it was broken under the old int-rounding code, but #84's seconds→milliseconds conversion makes fractional values work correctly (covered by `tests/test_retry_config.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)