### PR TITLE
feat(tools): add transport seam, typed search backend, result truncation, status-code errors

### DIFF
--- a/src/glean/agent_toolkit/tools/_common.py
+++ b/src/glean/agent_toolkit/tools/_common.py
@@ -35,11 +35,61 @@ class ToolResult(TypedDict):
     suggested_action: SuggestedAction | None
 
 
+def _sdk_error_status_code(exc: Exception) -> int | None:
+    """Return the HTTP status code carried by a Glean SDK error, if any."""
+    try:
+        from glean.api_client.errors import GleanBaseError
+    except ImportError:  # pragma: no cover - SDK is a hard dependency
+        return None
+
+    if isinstance(exc, GleanBaseError):
+        status_code = getattr(exc, "status_code", None)
+        if isinstance(status_code, int):
+            return status_code
+    return None
+
+
+def _classify_status_code(status_code: int) -> tuple[ErrorType, SuggestedAction]:
+    """Map an HTTP status code to an error type and suggested action."""
+    if status_code in (401, 403):
+        return "auth", "check_credentials"
+    if status_code == 404:
+        return "not_found", "rephrase_query"
+    if status_code == 408:
+        return "timeout", "retry"
+    if status_code == 429:
+        return "rate_limit", "retry"
+    if status_code in (400, 422):
+        return "validation", "rephrase_query"
+    if status_code >= 500:
+        return "api", "retry"
+    return "api", "retry"
+
+
+def _is_timeout_exception(exc: Exception) -> bool:
+    """Whether *exc* is a known timeout exception class."""
+    if isinstance(exc, TimeoutError):
+        return True
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx ships with the SDK
+        return False
+    return isinstance(exc, httpx.TimeoutException)
+
+
 def _classify_error(exc: Exception) -> tuple[ErrorType, SuggestedAction]:
-    """Classify an exception into an error type and suggested action."""
+    """Classify an exception into an error type and suggested action.
+
+    Glean SDK errors are classified by their HTTP status code first; the
+    string heuristics below remain as a fallback for non-SDK exceptions.
+    """
+    status_code = _sdk_error_status_code(exc)
+    if status_code is not None:
+        return _classify_status_code(status_code)
+
     msg = str(exc).lower()
 
-    if isinstance(exc, TimeoutError) or "timeout" in msg or "timed out" in msg:
+    if _is_timeout_exception(exc) or "timeout" in msg or "timed out" in msg:
         return "timeout", "retry"
 
     if isinstance(exc, ValueError):
@@ -135,6 +185,10 @@ def run_tool(
 ) -> ToolResult:
     """Execute a Glean stub tool and wrap the response.
 
+    Legacy entry point retained for backward compatibility; execution is
+    delegated to the transport seam's ``ToolsCallBackend`` so the
+    ``tools/call`` plumbing lives in one place.
+
     Args:
         tool_display_name: Display name for the tool
         parameters: Tool parameters
@@ -150,14 +204,10 @@ def run_tool(
 
             client = GleanContext().get_client()
 
-        from glean.agent_toolkit.tools._compat import resolve_method
+        from glean.agent_toolkit.tools._transport import ToolsCallBackend
 
-        run_fn = resolve_method(client.client.tools, "run", "execute")
-        result = run_fn(
-            name=tool_display_name,
-            parameters=parameters,
-        )
-        return make_ok(serialize_tool_result(result))
+        backend = ToolsCallBackend(tool_display_name)
+        return make_ok(backend.call_raw(client, parameters))
     except Exception as e:
         error_type, suggested_action = _classify_error(e)
         return make_error(str(e), error_type, suggested_action)

--- a/src/glean/agent_toolkit/tools/_transport.py
+++ b/src/glean/agent_toolkit/tools/_transport.py
@@ -1,0 +1,216 @@
+"""Private transport seam for the built-in tools.
+
+Every built-in tool declares *which* backend executes it (the assistant-UI
+``tools/call`` endpoint or a typed Client API endpoint) by registering a
+backend instance in the module-level registry. Execution, ``ToolResult``
+wrapping, error classification, and result-size capping all live here, so
+swapping a tool's backend is a one-line declaration change rather than a
+plumbing edit in the tool module.
+
+This module is private; the public contract (tool signatures, tool names,
+and the ``ToolResult`` envelope) is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+from glean.agent_toolkit.tools._common import (
+    ToolResult,
+    _classify_error,
+    make_error,
+    make_ok,
+    serialize_tool_result,
+)
+from glean.api_client import Glean, models
+
+MAX_RESULT_CHARS_ENV = "GLEAN_TOOL_MAX_RESULT_CHARS"
+"""Environment variable that overrides the serialized-result size cap."""
+
+DEFAULT_MAX_RESULT_CHARS = 40_000
+"""Default cap on the serialized size of a tools-call result payload."""
+
+TRUNCATION_MARKER = "[truncated]"
+"""Marker appended to a truncated payload so the LLM can tell it was cut."""
+
+
+def _max_result_chars() -> int:
+    """Return the result-size cap, honoring the env override.
+
+    A non-integer value falls back to the default; a value of zero or less
+    disables truncation entirely.
+    """
+    raw = os.environ.get(MAX_RESULT_CHARS_ENV)
+    if raw is None:
+        return DEFAULT_MAX_RESULT_CHARS
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_MAX_RESULT_CHARS
+
+
+def truncate_payload(payload: Any) -> Any:
+    """Cap the serialized size of *payload*.
+
+    When the JSON serialization of *payload* exceeds the configured cap
+    (:data:`DEFAULT_MAX_RESULT_CHARS`, overridable via
+    :data:`MAX_RESULT_CHARS_ENV`), the payload is replaced with a small
+    dict carrying the truncated serialization, an explicit
+    :data:`TRUNCATION_MARKER`, and a note explaining what happened. The
+    ``ToolResult`` envelope keys are never altered — the marker lives
+    inside the result payload.
+    """
+    limit = _max_result_chars()
+    if limit <= 0:
+        return payload
+
+    try:
+        serialized = json.dumps(payload, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        serialized = str(payload)
+
+    if len(serialized) <= limit:
+        return payload
+
+    return {
+        "truncated": True,
+        "max_chars": limit,
+        "note": (
+            f"Serialized result exceeded {limit} characters and was truncated. "
+            f"Set {MAX_RESULT_CHARS_ENV} to adjust the cap."
+        ),
+        "content": serialized[:limit] + TRUNCATION_MARKER,
+    }
+
+
+class Backend(Protocol):
+    """A strategy for executing one built-in tool against the Glean API."""
+
+    def execute(self, client: Glean, arguments: Mapping[str, Any]) -> Any:
+        """Run the tool with *arguments* and return the shaped payload."""
+        ...  # pragma: no cover
+
+
+def _coerce_parameter_value(value: Any) -> str:
+    """Serialize a tool argument into a ``ToolsCallParameter`` string value."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool | list | dict):
+        return json.dumps(value)
+    return str(value)
+
+
+class ToolsCallBackend:
+    """Backend for tools served by the assistant-UI ``tools/call`` endpoint.
+
+    Wraps the ``client.client.tools.run`` path (including the
+    ``run``/``execute`` method-name compatibility shim) and applies the
+    generic result-size cap, since this endpoint returns UI-shaped blobs
+    of unbounded size.
+    """
+
+    def __init__(self, display_name: str) -> None:
+        self.display_name = display_name
+
+    def execute(self, client: Glean, arguments: Mapping[str, Any]) -> Any:
+        """Map *arguments* to ``ToolsCallParameter`` objects and execute."""
+        parameters = {
+            key: models.ToolsCallParameter(name=key, value=_coerce_parameter_value(value))
+            for key, value in arguments.items()
+            if value is not None
+        }
+        return self.call_raw(client, parameters)
+
+    def call_raw(self, client: Glean, parameters: dict[str, models.ToolsCallParameter]) -> Any:
+        """Execute with pre-built ``ToolsCallParameter`` objects."""
+        from glean.agent_toolkit.tools._compat import resolve_method
+
+        run_fn = resolve_method(client.client.tools, "run", "execute")
+        result = run_fn(name=self.display_name, parameters=parameters)
+        return truncate_payload(serialize_tool_result(result))
+
+
+class TypedBackend:
+    """Backend for tools served by a typed Client API endpoint.
+
+    Args:
+        fn: Callable invoked as ``fn(client, **arguments)``; performs the
+            typed SDK call and returns the raw SDK response.
+        shaper: Optional callable that shapes the raw response into an
+            LLM-friendly payload. When ``None``, the response is
+            serialized as-is via ``serialize_tool_result``.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        shaper: Callable[[Any], Any] | None = None,
+    ) -> None:
+        self.fn = fn
+        self.shaper = shaper
+
+    def execute(self, client: Glean, arguments: Mapping[str, Any]) -> Any:
+        """Perform the typed call and shape the response."""
+        response = self.fn(client, **arguments)
+        if self.shaper is not None:
+            return self.shaper(response)
+        return serialize_tool_result(response)
+
+
+_BACKENDS: dict[str, Backend] = {}
+
+
+def register_backend(tool_name: str, backend: Backend) -> Backend:
+    """Register (or replace) the backend for *tool_name* and return it."""
+    _BACKENDS[tool_name] = backend
+    return backend
+
+
+def get_backend(tool_name: str) -> Backend | None:
+    """Return the backend registered for *tool_name*, if any."""
+    return _BACKENDS.get(tool_name)
+
+
+def execute_tool(
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    *,
+    client: Glean | None = None,
+) -> ToolResult:
+    """Execute the registered backend for *tool_name* and wrap the outcome.
+
+    This is the single execution seam for all built-in tools: client
+    resolution, backend dispatch, ``ToolResult`` wrapping, and error
+    classification happen here.
+
+    Args:
+        tool_name: The registered tool name (e.g. ``"glean_search"``).
+        arguments: The tool's high-level arguments.
+        client: Optional pre-configured Glean client. When ``None``, a
+            default client is created via ``GleanContext``.
+
+    Returns:
+        Structured ``ToolResult`` with status, result/error, and
+        classification.
+    """
+    backend = _BACKENDS.get(tool_name)
+    if backend is None:
+        return make_error(
+            f"No backend registered for tool '{tool_name}'",
+            error_type="validation",
+            suggested_action="rephrase_query",
+        )
+
+    try:
+        if client is None:
+            from glean.agent_toolkit.context import GleanContext
+
+            client = GleanContext().get_client()
+
+        return make_ok(backend.execute(client, arguments))
+    except Exception as e:
+        error_type, suggested_action = _classify_error(e)
+        return make_error(str(e), error_type, suggested_action)

--- a/src/glean/agent_toolkit/tools/calendar_search.py
+++ b/src/glean/agent_toolkit/tools/calendar_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_calendar_search", ToolsCallBackend("Meeting Lookup"))
 
 
 @tool_spec(
@@ -56,5 +63,4 @@ def calendar_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Meeting Lookup", parameters, client=client)
+    return execute_tool("glean_calendar_search", {"query": query}, client=client)

--- a/src/glean/agent_toolkit/tools/chat.py
+++ b/src/glean/agent_toolkit/tools/chat.py
@@ -9,9 +9,10 @@ from pydantic import BaseModel, Field
 from glean.agent_toolkit.decorators import tool_spec
 from glean.agent_toolkit.tools._common import (
     ToolResult,
-    run_with_error_handling,
     serialize_tool_result,
 )
+from glean.agent_toolkit.tools._transport import TypedBackend, execute_tool, register_backend
+from glean.api_client import Glean
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
@@ -75,6 +76,23 @@ def _extract_sources(response: Any) -> list[dict[str, Any]]:
     return sources
 
 
+def _create_chat(client: Glean, *, message: str) -> Any:
+    """Perform the typed ``POST /rest/api/v1/chat`` call."""
+    return client.client.chat.create(
+        messages=[{"fragments": [{"text": message}]}],
+    )
+
+
+def _shape_chat_response(response: Any) -> dict[str, Any]:
+    """Shape a ``ChatResponse`` into the ``ChatResult`` payload."""
+    answer = _extract_answer(response)
+    sources = _extract_sources(response)
+    return ChatResult(answer=answer, sources=sources).model_dump()
+
+
+register_backend("glean_chat", TypedBackend(_create_chat, _shape_chat_response))
+
+
 @tool_spec(
     name="glean_chat",
     description=(
@@ -111,13 +129,4 @@ def glean_chat(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-
-    def _do_chat() -> dict[str, Any]:
-        response = client.client.chat.create(
-            messages=[{"fragments": [{"text": message}]}],
-        )
-        answer = _extract_answer(response)
-        sources = _extract_sources(response)
-        return ChatResult(answer=answer, sources=sources).model_dump()
-
-    return run_with_error_handling(_do_chat)
+    return execute_tool("glean_chat", {"message": message}, client=client)

--- a/src/glean/agent_toolkit/tools/code_search.py
+++ b/src/glean/agent_toolkit/tools/code_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_code_search", ToolsCallBackend("Code Search"))
 
 
 @tool_spec(
@@ -56,5 +63,4 @@ def code_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Code Search", parameters, client=client)
+    return execute_tool("glean_code_search", {"query": query}, client=client)

--- a/src/glean/agent_toolkit/tools/employee_search.py
+++ b/src/glean/agent_toolkit/tools/employee_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_employee_search", ToolsCallBackend("Employee Search"))
 
 
 @tool_spec(
@@ -57,5 +64,4 @@ def employee_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Employee Search", parameters, client=client)
+    return execute_tool("glean_employee_search", {"query": query}, client=client)

--- a/src/glean/agent_toolkit/tools/gmail_search.py
+++ b/src/glean/agent_toolkit/tools/gmail_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_gmail_search", ToolsCallBackend("Gmail Search"))
 
 
 @tool_spec(
@@ -55,5 +62,4 @@ def gmail_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Gmail Search", parameters, client=client)
+    return execute_tool("glean_gmail_search", {"query": query}, client=client)

--- a/src/glean/agent_toolkit/tools/outlook_search.py
+++ b/src/glean/agent_toolkit/tools/outlook_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_outlook_search", ToolsCallBackend("Outlook Search"))
 
 
 @tool_spec(
@@ -55,5 +62,4 @@ def outlook_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Outlook Search", parameters, client=client)
+    return execute_tool("glean_outlook_search", {"query": query}, client=client)

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -8,12 +8,47 @@ from pydantic import Field
 
 import glean.agent_toolkit.tools._common as common
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, make_error, run_with_error_handling
-from glean.api_client import models
+from glean.agent_toolkit.tools._common import ToolResult, make_error
+from glean.agent_toolkit.tools._transport import TypedBackend, execute_tool, register_backend
+from glean.api_client import Glean, models
 from glean.api_client.client_documents import ClientDocuments
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+
+def _retrieve_documents(
+    client: Glean,
+    *,
+    document_id: str | None = None,
+    url: str | None = None,
+) -> Any:
+    """Perform the typed ``POST /rest/api/v1/getdocuments`` call."""
+    documents_client: ClientDocuments = client.client.documents
+
+    include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
+
+    if document_id is not None:
+        request = models.GetDocumentsRequest(
+            document_specs=[models.DocumentSpec2(id=document_id)],
+            include_fields=include_fields,
+        )
+    else:
+        request = models.GetDocumentsRequest(
+            document_specs=[models.DocumentSpec1(url=common.clean_query(url or ""))],
+            include_fields=include_fields,
+        )
+
+    from glean.agent_toolkit.tools._compat import resolve_kwarg, resolve_method
+
+    retrieve_fn = resolve_method(documents_client, "retrieve", "get")
+    # glean-api-client renamed the kwarg from `request` (<=0.6.x) to
+    # `get_documents_request` (>=0.15.x).
+    request_kwarg = resolve_kwarg(retrieve_fn, "get_documents_request", "request")
+    return retrieve_fn(**{request_kwarg: request})
+
+
+register_backend("glean_read_document", TypedBackend(_retrieve_documents))
 
 
 @tool_spec(
@@ -69,31 +104,8 @@ def read_document(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-
-    def _do_read() -> Any:
-        documents_client: ClientDocuments = client.client.documents
-
-        include_fields = [models.GetDocumentsRequestIncludeField.DOCUMENT_CONTENT]
-
-        if document_id is not None:
-            request = models.GetDocumentsRequest(
-                document_specs=[models.DocumentSpec2(id=document_id)],
-                include_fields=include_fields,
-            )
-        else:
-            request = models.GetDocumentsRequest(
-                document_specs=[models.DocumentSpec1(url=common.clean_query(url or ""))],
-                include_fields=include_fields,
-            )
-
-        from glean.agent_toolkit.tools._compat import resolve_kwarg, resolve_method
-
-        retrieve_fn = resolve_method(documents_client, "retrieve", "get")
-        # glean-api-client renamed the kwarg from `request` (<=0.6.x) to
-        # `get_documents_request` (>=0.15.x).
-        request_kwarg = resolve_kwarg(retrieve_fn, "get_documents_request", "request")
-        result = retrieve_fn(**{request_kwarg: request})
-
-        return common.serialize_tool_result(result)
-
-    return run_with_error_handling(_do_read)
+    return execute_tool(
+        "glean_read_document",
+        {"document_id": document_id, "url": url},
+        client=client,
+    )

--- a/src/glean/agent_toolkit/tools/search.py
+++ b/src/glean/agent_toolkit/tools/search.py
@@ -2,45 +2,118 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Annotated, Any
 
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import TypedBackend, execute_tool, register_backend
+from glean.api_client import Glean, models
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
 
+_SNIPPET_MAX_CHARS = 500
 
-def _build_search_params(
+
+def _to_facet_filters(filters: list[dict[str, Any]] | None) -> list[models.FacetFilter]:
+    """Map structured ``[{field, values, exclude?}]`` filters to facet filters.
+
+    Each filter dict becomes a ``FacetFilter`` on ``field``; every value
+    becomes a ``FacetFilterValue`` whose ``relationType`` is ``EQUALS``, or
+    ``NOT_EQUALS`` when ``exclude`` is true. Filters within a values list
+    are OR-ed and separate ``FacetFilter`` entries are AND-ed by the API.
+
+    Raises:
+        ValueError: If a filter dict is missing ``field`` or ``values``.
+    """
+    facet_filters: list[models.FacetFilter] = []
+    for spec in filters or []:
+        field = spec.get("field")
+        values = spec.get("values")
+        if not field or not values:
+            raise ValueError(
+                f"Each filter must include a non-empty 'field' and 'values'; got: {spec!r}"
+            )
+        relation_type = (
+            models.RelationType.NOT_EQUALS if spec.get("exclude") else models.RelationType.EQUALS
+        )
+        facet_filters.append(
+            models.FacetFilter(
+                field_name=str(field),
+                values=[
+                    models.FacetFilterValue(value=str(value), relation_type=relation_type)
+                    for value in values
+                ],
+            )
+        )
+    return facet_filters
+
+
+def _query_search(
+    client: Glean,
+    *,
     query: str,
     datasources: list[str] | None = None,
     filters: list[dict[str, Any]] | None = None,
     page_size: int = 10,
-) -> dict[str, Any]:
-    """Map high-level search parameters to ToolsCallParameter format.
+) -> models.SearchResponse:
+    """Perform a typed ``POST /rest/api/v1/search`` call.
 
-    Args:
-        query: The search query string.
-        datasources: Optional list of datasource names to restrict results.
-        filters: Optional structured filters ``[{field, values, exclude?}]``.
-        page_size: Number of results per page.
-
-    Returns:
-        Kwargs suitable for :func:`convert_to_tool_params`.
+    ``datasources`` maps to ``requestOptions.datasourcesFilter`` and
+    structured ``filters`` map to ``requestOptions.facetFilters``.
     """
-    # TODO: Replace with POST /api/search when available — this mapping can be deleted.
-    params: dict[str, Any] = {"query": query, "pageSize": str(page_size)}
+    facet_filters = _to_facet_filters(filters)
 
-    if datasources:
-        params["datasources"] = json.dumps(datasources)
+    request_options: models.SearchRequestOptions | None = None
+    if datasources or facet_filters:
+        request_options = models.SearchRequestOptions(
+            facet_bucket_size=0,
+            datasources_filter=list(datasources) if datasources else None,
+            facet_filters=facet_filters or None,
+        )
 
-    if filters:
-        params["filters"] = json.dumps(filters)
+    return client.client.search.query(
+        query=query,
+        page_size=page_size,
+        request_options=request_options,
+    )
 
-    return params
+
+def _shape_search_response(response: Any) -> dict[str, Any]:
+    """Shape a ``SearchResponse`` into a compact, LLM-friendly payload."""
+    shaped_results: list[dict[str, Any]] = []
+    for result in getattr(response, "results", None) or []:
+        document = getattr(result, "document", None)
+        snippets: list[str] = []
+        for snippet in getattr(result, "snippets", None) or []:
+            text = getattr(snippet, "text", None) or getattr(snippet, "snippet", None)
+            if not text:
+                continue
+            text = text.strip()
+            if len(text) > _SNIPPET_MAX_CHARS:
+                text = text[:_SNIPPET_MAX_CHARS] + "..."
+            snippets.append(text)
+
+        shaped_results.append(
+            {
+                "title": getattr(result, "title", None) or getattr(document, "title", None),
+                "url": getattr(result, "url", None) or getattr(document, "url", None),
+                "snippets": snippets,
+                "datasource": getattr(document, "datasource", None),
+                "document_id": getattr(document, "id", None),
+            }
+        )
+
+    return {
+        "results": shaped_results,
+        "result_count": len(shaped_results),
+        "has_more_results": bool(getattr(response, "has_more_results", None)),
+    }
+
+
+register_backend("glean_search", TypedBackend(_query_search, _shape_search_response))
 
 
 @tool_spec(
@@ -52,7 +125,10 @@ def _build_search_params(
         "INSTRUCTIONS:\n"
         "- Primary tool for all internal company knowledge.\n"
         "- Returns top relevant results, not exhaustive.\n"
-        '- For count queries ("how many..."), use the "statistics" field in the output.'
+        '- Output is {"results": [{title, url, snippets, datasource, document_id}], '
+        '"result_count", "has_more_results"}.\n'
+        '- "result_count" is the number of returned results, not a total corpus '
+        'count; "has_more_results" indicates more matches exist.'
     ),
 )
 def search(
@@ -101,6 +177,13 @@ def search(
 ) -> ToolResult:
     """Search Glean for relevant documents using the query.
 
+    Uses the typed Search API (``POST /rest/api/v1/search``). ``datasources``
+    map to the request's ``datasourcesFilter``; each structured filter maps
+    to a facet filter whose values carry ``relationType`` ``EQUALS`` (or
+    ``NOT_EQUALS`` when ``exclude`` is true). The success payload contains
+    ``results`` (each with title, url, snippets, datasource, document_id),
+    ``result_count``, and ``has_more_results``.
+
     Args:
         ctx: Optional Glean context for client injection.
         query: Search query with optional filters - API will validate filter syntax.
@@ -112,6 +195,13 @@ def search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    raw_params = _build_search_params(query, datasources, filters, page_size)
-    parameters = convert_to_tool_params(**raw_params)
-    return run_tool("Glean Search", parameters, client=client)
+    return execute_tool(
+        "glean_search",
+        {
+            "query": query,
+            "datasources": datasources,
+            "filters": filters,
+            "page_size": page_size,
+        },
+        client=client,
+    )

--- a/src/glean/agent_toolkit/tools/web_search.py
+++ b/src/glean/agent_toolkit/tools/web_search.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING, Annotated
 from pydantic import Field
 
 from glean.agent_toolkit.decorators import tool_spec
-from glean.agent_toolkit.tools._common import ToolResult, convert_to_tool_params, run_tool
+from glean.agent_toolkit.tools._common import ToolResult
+from glean.agent_toolkit.tools._transport import (
+    ToolsCallBackend,
+    execute_tool,
+    register_backend,
+)
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
+
+register_backend("glean_web_search", ToolsCallBackend("Gemini Web Search"))
 
 
 @tool_spec(
@@ -54,5 +61,4 @@ def web_search(
 
     ctx = ctx or GleanContext()
     client = ctx.get_client()
-    parameters = convert_to_tool_params(query=query)
-    return run_tool("Gemini Web Search", parameters, client=client)
+    return execute_tool("glean_web_search", {"query": query}, client=client)

--- a/tests/test_adk_invocation.py
+++ b/tests/test_adk_invocation.py
@@ -87,17 +87,17 @@ async def test_run_async_delivers_arguments_to_search() -> None:
 
     captured: dict[str, Any] = {}
 
-    def fake_run_tool(
-        tool_display_name: str,
-        parameters: dict[str, Any],
+    def fake_execute_tool(
+        tool_name: str,
+        arguments: dict[str, Any],
         *,
         client: Any = None,
     ) -> dict[str, Any]:
-        captured["tool_display_name"] = tool_display_name
-        captured["parameters"] = {key: value.value for key, value in parameters.items()}
+        captured["tool_name"] = tool_name
+        captured["arguments"] = dict(arguments)
         return {"status": "success", "result": "canned-result"}
 
-    with mock.patch.object(search_mod, "run_tool", fake_run_tool):
+    with mock.patch.object(search_mod, "execute_tool", fake_execute_tool):
         (tool,) = get_tools("adk", include=["glean_search"], client=_mock_client())
         result = await tool.run_async(
             args={"query": "test", "page_size": 5},
@@ -105,11 +105,11 @@ async def test_run_async_delivers_arguments_to_search() -> None:
         )
 
     assert result == {"status": "success", "result": "canned-result"}
-    assert captured["tool_display_name"] == "Glean Search"
+    assert captured["tool_name"] == "glean_search"
     # Previously the (*args, **kwargs) wrapper signature made ADK drop every
     # argument, so the query never reached the tool implementation.
-    assert captured["parameters"]["query"] == "test"
-    assert captured["parameters"]["pageSize"] == "5"
+    assert captured["arguments"]["query"] == "test"
+    assert captured["arguments"]["page_size"] == 5
 
 
 async def test_custom_multi_arg_tool_via_adk(unregister_tools: list[str]) -> None:

--- a/tests/test_client_lifecycle.py
+++ b/tests/test_client_lifecycle.py
@@ -17,7 +17,7 @@ from glean.agent_toolkit.context import GleanContext
 from glean.agent_toolkit.tools.search import search
 
 SERVER_URL = "https://example.glean.com"
-TOOLS_CALL_URL = f"{SERVER_URL}/rest/api/v1/tools/call"
+SEARCH_URL = f"{SERVER_URL}/rest/api/v1/search"
 
 
 @pytest.fixture
@@ -30,8 +30,8 @@ def _mock_tools_call(httpx_mock: HTTPXMock, count: int = 1) -> None:
     for _ in range(count):
         httpx_mock.add_response(
             method="POST",
-            url=TOOLS_CALL_URL,
-            json={"rawResponse": {"results": []}},
+            url=SEARCH_URL,
+            json={"results": []},
         )
 
 

--- a/tests/test_crewai_invocation.py
+++ b/tests/test_crewai_invocation.py
@@ -76,18 +76,18 @@ def test_crewai_glean_search_run_with_mocked_glean_layer(
     }
     calls: list[dict[str, Any]] = []
 
-    def fake_run_tool(tool_display_name: str, parameters: Any, **kwargs: Any) -> dict[str, Any]:
-        calls.append({"name": tool_display_name, "parameters": parameters})
+    def fake_execute_tool(tool_name: str, arguments: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"name": tool_name, "arguments": dict(arguments)})
         return canned
 
-    monkeypatch.setattr(search_mod, "run_tool", fake_run_tool)
+    monkeypatch.setattr(search_mod, "execute_tool", fake_execute_tool)
 
     tool = search_mod.search.as_crewai_tool()
     output = tool.run(query="test")
 
     assert len(calls) == 1
-    assert calls[0]["name"] == "Glean Search"
-    assert calls[0]["parameters"]["query"].value == "test"
+    assert calls[0]["name"] == "glean_search"
+    assert calls[0]["arguments"]["query"] == "test"
 
     assert json.loads(output) == canned
 

--- a/tests/test_invocation_matrix.py
+++ b/tests/test_invocation_matrix.py
@@ -57,6 +57,7 @@ except ImportError:  # pragma: no cover
 
 BASE_URL = "https://test-instance-be.glean.com"
 TOOLS_CALL_URL = f"{BASE_URL}/rest/api/v1/tools/call"
+SEARCH_URL = f"{BASE_URL}/rest/api/v1/search"
 CHAT_URL = f"{BASE_URL}/rest/api/v1/chat"
 GET_DOCUMENTS_URL = f"{BASE_URL}/rest/api/v1/getdocuments"
 
@@ -119,6 +120,47 @@ def _tools_call_case(
         args=args,
         url=TOOLS_CALL_URL,
         response_json={"rawResponse": raw_response},
+        check_request=check_request,
+        check_result=check_result,
+    )
+
+
+def _search_case() -> ToolCase:
+    """Build the case for glean_search (typed POST /rest/api/v1/search)."""
+    query = "quarterly financial results"
+
+    def check_request(body: dict[str, Any]) -> None:
+        assert body["query"] == query
+        assert body["pageSize"] == 5
+
+    def check_result(result: Any) -> None:
+        assert result["result_count"] == 1
+        assert result["has_more_results"] is False
+        assert result["results"] == [
+            {
+                "title": "Q3 Financial Results",
+                "url": "https://drive.example.com/doc/abc123",
+                "snippets": ["Revenue grew 18% quarter over quarter."],
+                "datasource": "gdrive",
+                "document_id": "doc-1",
+            }
+        ]
+
+    return ToolCase(
+        tool_name="glean_search",
+        args={"query": query, "page_size": 5},
+        url=SEARCH_URL,
+        response_json={
+            "results": [
+                {
+                    "title": "Q3 Financial Results",
+                    "url": "https://drive.example.com/doc/abc123",
+                    "document": {"id": "doc-1", "datasource": "gdrive"},
+                    "snippets": [{"text": "Revenue grew 18% quarter over quarter."}],
+                }
+            ],
+            "hasMoreResults": False,
+        },
         check_request=check_request,
         check_result=check_result,
     )
@@ -197,13 +239,8 @@ def _read_document_case() -> ToolCase:
 
 
 TOOL_CASES: list[ToolCase] = [
-    # Multi-arg case: query + page_size must both reach the wire.
-    _tools_call_case(
-        "glean_search",
-        "Glean Search",
-        args={"query": "quarterly financial results", "page_size": 5},
-        expected_params={"query": "quarterly financial results", "pageSize": "5"},
-    ),
+    # Multi-arg case: query + page_size must both reach the wire (typed endpoint).
+    _search_case(),
     _tools_call_case(
         "glean_web_search",
         "Gemini Web Search",

--- a/tests/test_langchain_invocation.py
+++ b/tests/test_langchain_invocation.py
@@ -27,7 +27,7 @@ CANNED_PAYLOAD = "CANNED_LANGCHAIN_PAYLOAD"
 def patched_run_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """Replace the Glean network call with a canned ToolResult.
 
-    ``search`` binds ``run_tool`` into its module namespace at import
+    ``search`` binds ``execute_tool`` into its module namespace at import
     time, so patch it there. Env vars are set so the (unused) client
     construction inside the tool does not fail.
     """
@@ -36,20 +36,20 @@ def patched_run_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     captured: dict[str, Any] = {}
 
-    def fake_run_tool(
-        tool_display_name: str,
-        parameters: dict[str, Any],
+    def fake_execute_tool(
+        tool_name: str,
+        arguments: dict[str, Any],
         *,
         client: Any = None,
     ) -> ToolResult:
-        captured["tool_display_name"] = tool_display_name
-        captured["parameters"] = {name: param.value for name, param in parameters.items()}
+        captured["tool_name"] = tool_name
+        captured["arguments"] = dict(arguments)
         return make_ok({"marker": CANNED_PAYLOAD})
 
     # The tools package re-exports the `search` function under the same
     # name as its module, so resolve the module object explicitly.
     search_module = importlib.import_module("glean.agent_toolkit.tools.search")
-    monkeypatch.setattr(search_module, "run_tool", fake_run_tool)
+    monkeypatch.setattr(search_module, "execute_tool", fake_execute_tool)
     return captured
 
 
@@ -68,9 +68,9 @@ def test_invoke_multi_arg_through_langchain(patched_run_tool: dict[str, Any]) ->
 
     assert isinstance(result, str)
     assert CANNED_PAYLOAD in result
-    assert patched_run_tool["tool_display_name"] == "Glean Search"
-    assert patched_run_tool["parameters"]["query"] == "test"
-    assert patched_run_tool["parameters"]["pageSize"] == "5"
+    assert patched_run_tool["tool_name"] == "glean_search"
+    assert patched_run_tool["arguments"]["query"] == "test"
+    assert patched_run_tool["arguments"]["page_size"] == 5
 
 
 async def test_ainvoke_multi_arg_through_langchain(patched_run_tool: dict[str, Any]) -> None:
@@ -80,8 +80,8 @@ async def test_ainvoke_multi_arg_through_langchain(patched_run_tool: dict[str, A
 
     assert isinstance(result, str)
     assert CANNED_PAYLOAD in result
-    assert patched_run_tool["parameters"]["query"] == "async test"
-    assert patched_run_tool["parameters"]["pageSize"] == "5"
+    assert patched_run_tool["arguments"]["query"] == "async test"
+    assert patched_run_tool["arguments"]["page_size"] == 5
 
 
 def test_custom_multi_arg_tool_invocable() -> None:

--- a/tests/test_openai_invocation.py
+++ b/tests/test_openai_invocation.py
@@ -95,15 +95,15 @@ async def test_on_invoke_tool_framework_path(monkeypatch: pytest.MonkeyPatch) ->
     canned = make_ok({"documents": [{"title": "canned-doc"}]})
     captured: dict[str, Any] = {}
 
-    def fake_run_tool(tool_display_name: str, parameters: Any, *, client: Any = None) -> Any:
-        captured["tool_display_name"] = tool_display_name
-        captured["parameters"] = parameters
+    def fake_execute_tool(tool_name: str, arguments: Any, *, client: Any = None) -> Any:
+        captured["tool_name"] = tool_name
+        captured["arguments"] = dict(arguments)
         return canned
 
     import importlib
 
     search_module = importlib.import_module("glean.agent_toolkit.tools.search")
-    monkeypatch.setattr(search_module, "run_tool", fake_run_tool)
+    monkeypatch.setattr(search_module, "execute_tool", fake_execute_tool)
 
     tools = get_tools("openai", include=["glean_search"], client=_mock_client())
     assert len(tools) == 1
@@ -115,7 +115,7 @@ async def test_on_invoke_tool_framework_path(monkeypatch: pytest.MonkeyPatch) ->
     result = json.loads(result_str)
     assert result["status"] == "ok"
     assert result["result"] == {"documents": [{"title": "canned-doc"}]}
-    assert captured["tool_display_name"] == "Glean Search"
+    assert captured["tool_name"] == "glean_search"
 
 
 def test_read_document_optional_params_schema_valid() -> None:

--- a/tests/test_transport_contracts.py
+++ b/tests/test_transport_contracts.py
@@ -7,9 +7,8 @@ with response JSON shaped like the real backend payloads and verify:
 
 1. The outbound request body matches the wire contract of the endpoint.
 2. Deserialization runs through the real SDK models
-   (``ToolsCallResponse``, ``ChatResponse``, ``GetDocumentsResponse``).
-3. The tool returns a correct, fully structured ``ToolResult``, with
-   camelCase field aliases preserved by ``serialize_tool_result``.
+   (``SearchResponse``, ``ChatResponse``, ``GetDocumentsResponse``).
+3. The tool returns a correct, fully structured ``ToolResult``.
 """
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ from glean.agent_toolkit.tools.read_document import read_document
 from glean.agent_toolkit.tools.search import search
 
 BASE_URL = "https://test-instance-be.glean.com"
-TOOLS_CALL_URL = f"{BASE_URL}/rest/api/v1/tools/call"
+SEARCH_URL = f"{BASE_URL}/rest/api/v1/search"
 CHAT_URL = f"{BASE_URL}/rest/api/v1/chat"
 GET_DOCUMENTS_URL = f"{BASE_URL}/rest/api/v1/getdocuments"
 
@@ -36,97 +35,98 @@ def _request_body(httpx_mock: HTTPXMock) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# search -> POST /rest/api/v1/tools/call (ToolsCallResponse)
+# search -> POST /rest/api/v1/search (SearchResponse)
 # ---------------------------------------------------------------------------
 
 
-REALISTIC_SEARCH_RAW_RESPONSE: dict[str, Any] = {
+REALISTIC_SEARCH_RESPONSE: dict[str, Any] = {
     "results": [
         {
             "title": "Q3 Financial Results",
             "url": "https://drive.google.com/file/d/abc123",
-            "datasource": "gdrive",
-            "snippets": [
-                {"snippet": "Revenue grew 18% quarter over quarter.", "mimeType": "text/plain"}
-            ],
-            "metadata": {
-                "author": {"name": "Test User"},
-                "updateTime": "2025-10-01T12:00:00Z",
+            "document": {
+                "id": "doc-1",
+                "datasource": "gdrive",
+                "title": "Q3 Financial Results",
+                "url": "https://drive.google.com/file/d/abc123",
             },
+            "snippets": [
+                {"text": "Revenue grew 18% quarter over quarter.", "mimeType": "text/plain"}
+            ],
         },
         {
             "title": "Q3 Board Deck",
             "url": "https://docs.google.com/presentation/d/def456",
-            "datasource": "gdrive",
-            "snippets": [{"snippet": "Q3 highlights and FY outlook."}],
+            "document": {"id": "doc-2", "datasource": "gdrive"},
+            "snippets": [{"text": "Q3 highlights and FY outlook."}],
         },
     ],
     "trackingToken": "tracking-token-1",
     "hasMoreResults": False,
+    "backendTimeMillis": 42,
 }
 
 
-def test_search_deserializes_realistic_tools_call_response(httpx_mock: HTTPXMock) -> None:
-    """A realistic ToolsCallResponse round-trips into ToolResult.result."""
+def test_search_deserializes_realistic_search_response(httpx_mock: HTTPXMock) -> None:
+    """A realistic SearchResponse round-trips into the shaped ToolResult."""
     httpx_mock.add_response(
         method="POST",
-        url=TOOLS_CALL_URL,
-        json={"rawResponse": REALISTIC_SEARCH_RAW_RESPONSE, "error": None},
+        url=SEARCH_URL,
+        json=REALISTIC_SEARCH_RESPONSE,
     )
 
     result = search(query="quarterly financial results", page_size=2)
 
     assert result["status"] == "ok"
     assert result["error"] is None
-    # serialize_tool_result dumps the SDK model with by_alias=True, so the
-    # camelCase keys of the raw payload must survive verbatim. Field-wise
-    # check: older glean-api-client versions dump unset optional fields as
-    # explicit None ("error": None); newer versions omit them entirely.
-    assert result["result"]["rawResponse"] == REALISTIC_SEARCH_RAW_RESPONSE
-    assert result["result"].get("error") is None
+
+    payload = result["result"]
+    assert payload["result_count"] == 2
+    assert payload["has_more_results"] is False
+    assert payload["results"][0] == {
+        "title": "Q3 Financial Results",
+        "url": "https://drive.google.com/file/d/abc123",
+        "snippets": ["Revenue grew 18% quarter over quarter."],
+        "datasource": "gdrive",
+        "document_id": "doc-1",
+    }
 
     body = _request_body(httpx_mock)
-    assert body["name"] == "Glean Search"
-    assert body["parameters"]["query"]["value"] == "quarterly financial results"
-    assert body["parameters"]["pageSize"]["value"] == "2"
+    assert body["query"] == "quarterly financial results"
+    assert body["pageSize"] == 2
+    assert "requestOptions" not in body
 
 
 def test_search_sends_datasources_and_filters_on_the_wire(httpx_mock: HTTPXMock) -> None:
-    """Structured args are JSON-encoded into ToolsCallParameter values."""
+    """Structured args map to requestOptions on the typed endpoint."""
     httpx_mock.add_response(
         method="POST",
-        url=TOOLS_CALL_URL,
-        json={"rawResponse": {"results": []}},
+        url=SEARCH_URL,
+        json={"results": []},
     )
 
-    filters = [{"field": "app", "values": ["jira"], "exclude": False}]
+    filters = [
+        {"field": "type", "values": ["Presentation"]},
+        {"field": "from", "values": ["bot"], "exclude": True},
+    ]
     result = search(query="sprint tasks", datasources=["jira", "confluence"], filters=filters)
 
     assert result["status"] == "ok"
+    assert result["result"] == {"results": [], "result_count": 0, "has_more_results": False}
 
     body = _request_body(httpx_mock)
-    params = body["parameters"]
-    assert json.loads(params["datasources"]["value"]) == ["jira", "confluence"]
-    assert json.loads(params["filters"]["value"]) == filters
-
-
-def test_search_tool_level_error_field_is_preserved(httpx_mock: HTTPXMock) -> None:
-    """A tools/call payload carrying an error field still deserializes."""
-    httpx_mock.add_response(
-        method="POST",
-        url=TOOLS_CALL_URL,
-        json={"rawResponse": None, "error": "Tool execution failed upstream"},
-    )
-
-    result = search(query="anything")
-
-    # The HTTP call itself succeeded, so the ToolResult is "ok" and the
-    # tool-level error is surfaced inside the deserialized payload.
-    # (Field-wise: newer glean-api-client versions omit the unset
-    # rawResponse key instead of dumping "rawResponse": None.)
-    assert result["status"] == "ok"
-    assert result["result"].get("rawResponse") is None
-    assert result["result"]["error"] == "Tool execution failed upstream"
+    options = body["requestOptions"]
+    assert options["datasourcesFilter"] == ["jira", "confluence"]
+    assert options["facetFilters"] == [
+        {
+            "fieldName": "type",
+            "values": [{"value": "Presentation", "relationType": "EQUALS"}],
+        },
+        {
+            "fieldName": "from",
+            "values": [{"value": "bot", "relationType": "NOT_EQUALS"}],
+        },
+    ]
 
 
 def test_search_http_401_maps_to_auth_error(httpx_mock: HTTPXMock) -> None:
@@ -137,7 +137,7 @@ def test_search_http_401_maps_to_auth_error(httpx_mock: HTTPXMock) -> None:
     """
     httpx_mock.add_response(
         method="POST",
-        url=TOOLS_CALL_URL,
+        url=SEARCH_URL,
         status_code=401,
         json={"error": "Invalid token"},
     )

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import httpx
+import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from glean.agent_toolkit.context import GleanContext
@@ -13,6 +15,7 @@ from glean.agent_toolkit.tools._common import (
     run_tool,
     serialize_tool_result,
 )
+from glean.api_client import errors as sdk_errors
 
 
 class _Item(BaseModel):
@@ -128,4 +131,84 @@ def test_classify_error_connection() -> None:
 def test_classify_error_generic() -> None:
     error_type, action = _classify_error(RuntimeError("unknown"))
     assert error_type == "api"
+    assert action == "retry"
+
+
+def _sdk_error(status_code: int) -> sdk_errors.GleanError:
+    """Build a real SDK error instance carrying *status_code*."""
+    response = httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("POST", "https://test-instance-be.glean.com/rest/api/v1/search"),
+        text="upstream failure",
+    )
+    return sdk_errors.GleanError("API error occurred", response, "upstream failure")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_type", "expected_action"),
+    [
+        (400, "validation", "rephrase_query"),
+        (401, "auth", "check_credentials"),
+        (403, "auth", "check_credentials"),
+        (404, "not_found", "rephrase_query"),
+        (408, "timeout", "retry"),
+        (418, "api", "retry"),  # unmapped 4xx falls back to api/retry
+        (422, "validation", "rephrase_query"),
+        (429, "rate_limit", "retry"),
+        (500, "api", "retry"),
+        (502, "api", "retry"),
+        (503, "api", "retry"),
+    ],
+)
+def test_classify_error_sdk_status_codes(
+    status_code: int, expected_type: str, expected_action: str
+) -> None:
+    """Real SDK error instances are classified by their status code."""
+    error_type, action = _classify_error(_sdk_error(status_code))
+    assert error_type == expected_type
+    assert action == expected_action
+
+
+def test_classify_error_sdk_status_beats_message_heuristics() -> None:
+    """The status code wins even when the body mentions other keywords."""
+    response = httpx.Response(
+        status_code=403,
+        request=httpx.Request("POST", "https://example.com"),
+        text="deadline timed out while checking rate limit",
+    )
+    error = sdk_errors.GleanError("API error occurred", response)
+
+    error_type, action = _classify_error(error)
+
+    assert error_type == "auth"
+    assert action == "check_credentials"
+
+
+def test_classify_error_glean_data_error_uses_status_code() -> None:
+    """Subclasses of the SDK base error are classified the same way."""
+    response = httpx.Response(
+        status_code=422,
+        request=httpx.Request("POST", "https://example.com"),
+        text="{}",
+    )
+    data = sdk_errors.GleanDataErrorData()
+    error = sdk_errors.GleanDataError(data, response)
+
+    error_type, action = _classify_error(error)
+
+    assert error_type == "validation"
+    assert action == "rephrase_query"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectTimeout("connect exceeded deadline"),
+        httpx.ReadTimeout("read exceeded deadline"),
+        httpx.PoolTimeout("pool exceeded deadline"),
+    ],
+)
+def test_classify_error_httpx_timeout_classes(exc: Exception) -> None:
+    error_type, action = _classify_error(exc)
+    assert error_type == "timeout"
     assert action == "retry"

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -1,38 +1,148 @@
-"""Tests for the Search tool."""
+"""Tests for the Search tool (typed Search API backend)."""
 
-import json
+from typing import Any
 from unittest.mock import MagicMock
 
 from glean.agent_toolkit.context import GleanContext
-from glean.agent_toolkit.tools.search import _build_search_params, search
+from glean.agent_toolkit.tools.search import (
+    _SNIPPET_MAX_CHARS,
+    _shape_search_response,
+    _to_facet_filters,
+    search,
+)
+from glean.api_client import models
 
 
-def _make_ctx(return_value: object = None) -> GleanContext:
+def _make_ctx(response: object = None) -> GleanContext:
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
-    mock_client.client.tools.run.return_value = (
-        return_value if return_value is not None else {"data": "mock"}
+    mock_client.client.search.query.return_value = (
+        response if response is not None else models.SearchResponse(results=[])
     )
     return GleanContext(client=mock_client)
 
 
-def test_search_success() -> None:
-    mock_result = {"data": "mock"}
-    ctx = _make_ctx(mock_result)
+def _query_kwargs(ctx: GleanContext) -> dict[str, Any]:
+    mock_client = ctx.get_client()
+    return mock_client.client.search.query.call_args.kwargs  # type: ignore[union-attr]
 
-    result = search(ctx, query="company holidays 2025")
+
+def _sdk_response() -> models.SearchResponse:
+    return models.SearchResponse(
+        results=[
+            models.SearchResult(
+                title="Q3 Financial Results",
+                url="https://drive.example.com/doc/abc123",
+                document=models.Document(id="doc-1", datasource="gdrive"),
+                snippets=[
+                    models.SearchResultSnippet(text="Revenue grew 18% quarter over quarter."),
+                ],
+            ),
+            models.SearchResult(
+                title="Q3 Board Deck",
+                url="https://docs.example.com/deck/def456",
+                document=models.Document(id="doc-2", datasource="gdrive"),
+                snippets=[models.SearchResultSnippet(text="Q3 highlights and FY outlook.")],
+            ),
+        ],
+        has_more_results=True,
+    )
+
+
+def test_search_success_returns_shaped_results() -> None:
+    ctx = _make_ctx(_sdk_response())
+
+    result = search(ctx, query="quarterly financial results")
 
     assert result["status"] == "ok"
-    assert result["result"] == mock_result
     assert result["error"] is None
+
+    payload = result["result"]
+    assert payload["result_count"] == 2
+    assert payload["has_more_results"] is True
+    first = payload["results"][0]
+    assert first == {
+        "title": "Q3 Financial Results",
+        "url": "https://drive.example.com/doc/abc123",
+        "snippets": ["Revenue grew 18% quarter over quarter."],
+        "datasource": "gdrive",
+        "document_id": "doc-1",
+    }
+
+
+def test_search_sends_query_and_page_size() -> None:
+    ctx = _make_ctx()
+
+    result = search(ctx, query="company holidays 2025", page_size=25)
+
+    assert result["status"] == "ok"
+    kwargs = _query_kwargs(ctx)
+    assert kwargs["query"] == "company holidays 2025"
+    assert kwargs["page_size"] == 25
+    assert kwargs["request_options"] is None
+
+
+def test_search_default_page_size() -> None:
+    ctx = _make_ctx()
+
+    search(ctx, query="docs")
+
+    assert _query_kwargs(ctx)["page_size"] == 10
+
+
+def test_search_with_datasources() -> None:
+    ctx = _make_ctx()
+
+    result = search(ctx, query="onboarding", datasources=["confluence", "gdrive"])
+
+    assert result["status"] == "ok"
+    request_options = _query_kwargs(ctx)["request_options"]
+    assert isinstance(request_options, models.SearchRequestOptions)
+    assert request_options.datasources_filter == ["confluence", "gdrive"]
+    assert request_options.facet_filters is None
+
+
+def test_search_with_filters_maps_to_facet_filters() -> None:
+    ctx = _make_ctx()
+    filters = [{"field": "type", "values": ["Presentation", "Spreadsheet"]}]
+
+    result = search(ctx, query="sprint tasks", filters=filters)
+
+    assert result["status"] == "ok"
+    request_options = _query_kwargs(ctx)["request_options"]
+    facet_filters = request_options.facet_filters
+    assert len(facet_filters) == 1
+    assert facet_filters[0].field_name == "type"
+    assert [v.value for v in facet_filters[0].values] == ["Presentation", "Spreadsheet"]
+    assert all(v.relation_type == models.RelationType.EQUALS for v in facet_filters[0].values)
+
+
+def test_search_exclude_filter_maps_to_not_equals() -> None:
+    ctx = _make_ctx()
+    filters = [{"field": "from", "values": ["bot"], "exclude": True}]
+
+    search(ctx, query="deploy failures", filters=filters)
+
+    facet_filters = _query_kwargs(ctx)["request_options"].facet_filters
+    assert facet_filters[0].values[0].relation_type == models.RelationType.NOT_EQUALS
+
+
+def test_search_invalid_filter_is_validation_error() -> None:
+    ctx = _make_ctx()
+
+    result = search(ctx, query="docs", filters=[{"values": ["x"]}])
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "validation"
+    assert result["suggested_action"] == "rephrase_query"
 
 
 def test_search_api_error() -> None:
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
-    mock_client.client.tools.run.side_effect = Exception("API Error")
+    mock_client.client.search.query.side_effect = Exception("API Error")
     ctx = GleanContext(client=mock_client)
 
     result = search(ctx, query="invalid query that causes error")
@@ -42,62 +152,55 @@ def test_search_api_error() -> None:
     assert result["result"] is None
 
 
-def test_search_with_datasources() -> None:
-    ctx = _make_ctx()
-    result = search(ctx, query="onboarding", datasources=["confluence", "gdrive"])
+def test_to_facet_filters_requires_field_and_values() -> None:
+    import pytest
 
-    assert result["status"] == "ok"
-    mock_client = ctx.get_client()
-    call_params = mock_client.client.tools.run.call_args.kwargs["parameters"]  # type: ignore[union-attr]
-    assert "datasources" in call_params
-    assert json.loads(call_params["datasources"].value) == ["confluence", "gdrive"]
+    with pytest.raises(ValueError):
+        _to_facet_filters([{"field": "app", "values": []}])
+    with pytest.raises(ValueError):
+        _to_facet_filters([{"values": ["jira"]}])
 
 
-def test_search_with_filters() -> None:
-    ctx = _make_ctx()
-    filters = [{"field": "app", "values": ["jira"], "exclude": False}]
-    result = search(ctx, query="sprint tasks", filters=filters)
-
-    assert result["status"] == "ok"
-    mock_client = ctx.get_client()
-    call_params = mock_client.client.tools.run.call_args.kwargs["parameters"]  # type: ignore[union-attr]
-    assert "filters" in call_params
-    assert json.loads(call_params["filters"].value) == filters
+def test_to_facet_filters_empty_input() -> None:
+    assert _to_facet_filters(None) == []
+    assert _to_facet_filters([]) == []
 
 
-def test_search_with_page_size() -> None:
-    ctx = _make_ctx()
-    result = search(ctx, query="docs", page_size=25)
-
-    assert result["status"] == "ok"
-    mock_client = ctx.get_client()
-    call_params = mock_client.client.tools.run.call_args.kwargs["parameters"]  # type: ignore[union-attr]
-    assert call_params["pageSize"].value == "25"
-
-
-def test_search_default_page_size() -> None:
-    ctx = _make_ctx()
-    result = search(ctx, query="docs")
-
-    assert result["status"] == "ok"
-    mock_client = ctx.get_client()
-    call_params = mock_client.client.tools.run.call_args.kwargs["parameters"]  # type: ignore[union-attr]
-    assert call_params["pageSize"].value == "10"
-
-
-def test_build_search_params_minimal() -> None:
-    params = _build_search_params("hello")
-    assert params == {"query": "hello", "pageSize": "10"}
-
-
-def test_build_search_params_full() -> None:
-    params = _build_search_params(
-        "hello",
-        datasources=["slack"],
-        filters=[{"field": "owner", "values": ["alice"]}],
-        page_size=5,
+def test_shape_search_response_truncates_long_snippets() -> None:
+    long_text = "x" * (_SNIPPET_MAX_CHARS + 100)
+    response = models.SearchResponse(
+        results=[
+            models.SearchResult(
+                title="Doc",
+                url="https://example.com/doc",
+                snippets=[models.SearchResultSnippet(text=long_text)],
+            )
+        ]
     )
-    assert params["query"] == "hello"
-    assert params["pageSize"] == "5"
-    assert json.loads(params["datasources"]) == ["slack"]
-    assert json.loads(params["filters"]) == [{"field": "owner", "values": ["alice"]}]
+
+    shaped = _shape_search_response(response)
+
+    snippet = shaped["results"][0]["snippets"][0]
+    assert snippet == "x" * _SNIPPET_MAX_CHARS + "..."
+
+
+def test_shape_search_response_falls_back_to_deprecated_snippet_field() -> None:
+    response = models.SearchResponse(
+        results=[
+            models.SearchResult(
+                title="Doc",
+                url="https://example.com/doc",
+                snippets=[models.SearchResultSnippet(snippet="legacy snippet text")],
+            )
+        ]
+    )
+
+    shaped = _shape_search_response(response)
+
+    assert shaped["results"][0]["snippets"] == ["legacy snippet text"]
+
+
+def test_shape_search_response_handles_empty_response() -> None:
+    shaped = _shape_search_response(models.SearchResponse())
+
+    assert shaped == {"results": [], "result_count": 0, "has_more_results": False}

--- a/tests/tools/test_transport.py
+++ b/tests/tools/test_transport.py
@@ -1,0 +1,293 @@
+"""Tests for the private transport seam (_transport.py)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+
+from glean.agent_toolkit.tools import _transport
+from glean.agent_toolkit.tools._transport import (
+    DEFAULT_MAX_RESULT_CHARS,
+    MAX_RESULT_CHARS_ENV,
+    TRUNCATION_MARKER,
+    ToolsCallBackend,
+    TypedBackend,
+    execute_tool,
+    get_backend,
+    register_backend,
+    truncate_payload,
+)
+
+
+class _AliasModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    camel_case_field: str = Field(alias="camelCaseField")
+
+
+def _mock_client(tools_run_return: object = None) -> MagicMock:
+    client = MagicMock()
+    client.client.tools.run.return_value = (
+        tools_run_return if tools_run_return is not None else {"data": "mock"}
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_payload_under_limit_passthrough() -> None:
+    payload = {"small": "payload"}
+    assert truncate_payload(payload) is payload
+
+
+def test_truncate_payload_over_default_limit() -> None:
+    payload = {"blob": "x" * (DEFAULT_MAX_RESULT_CHARS + 1000)}
+
+    truncated = truncate_payload(payload)
+
+    assert truncated["truncated"] is True
+    assert truncated["max_chars"] == DEFAULT_MAX_RESULT_CHARS
+    assert MAX_RESULT_CHARS_ENV in truncated["note"]
+    assert truncated["content"].endswith(TRUNCATION_MARKER)
+    # content is the capped serialization plus the marker
+    assert len(truncated["content"]) == DEFAULT_MAX_RESULT_CHARS + len(TRUNCATION_MARKER)
+
+
+def test_truncate_payload_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MAX_RESULT_CHARS_ENV, "100")
+
+    payload = {"blob": "y" * 500}
+    truncated = truncate_payload(payload)
+
+    assert truncated["truncated"] is True
+    assert truncated["max_chars"] == 100
+    assert truncated["content"] == json.dumps(payload)[:100] + TRUNCATION_MARKER
+
+
+def test_truncate_payload_env_invalid_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MAX_RESULT_CHARS_ENV, "not-a-number")
+
+    payload = {"small": "payload"}
+    assert truncate_payload(payload) is payload
+    assert _transport._max_result_chars() == DEFAULT_MAX_RESULT_CHARS
+
+
+def test_truncate_payload_env_zero_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MAX_RESULT_CHARS_ENV, "0")
+
+    payload = {"blob": "z" * (DEFAULT_MAX_RESULT_CHARS * 2)}
+    assert truncate_payload(payload) is payload
+
+
+def test_truncate_payload_unserializable_uses_str(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MAX_RESULT_CHARS_ENV, "10")
+
+    circular: dict[str, Any] = {}
+    circular["self"] = circular  # json.dumps raises ValueError
+
+    truncated = truncate_payload(circular)
+
+    assert truncated["truncated"] is True
+    assert truncated["content"] == str(circular)[:10] + TRUNCATION_MARKER
+
+
+# ---------------------------------------------------------------------------
+# ToolsCallBackend
+# ---------------------------------------------------------------------------
+
+
+def test_tools_call_backend_maps_and_coerces_arguments() -> None:
+    client = _mock_client({"raw": "ok"})
+    backend = ToolsCallBackend("Glean Search")
+
+    result = backend.execute(
+        client,
+        {
+            "query": "hello",
+            "page_size": 5,
+            "datasources": ["jira"],
+            "flag": True,
+            "skipped": None,
+        },
+    )
+
+    assert result == {"raw": "ok"}
+    kwargs = client.client.tools.run.call_args.kwargs
+    assert kwargs["name"] == "Glean Search"
+    params = kwargs["parameters"]
+    assert set(params) == {"query", "page_size", "datasources", "flag"}
+    assert params["query"].value == "hello"
+    assert params["page_size"].value == "5"
+    assert json.loads(params["datasources"].value) == ["jira"]
+    assert json.loads(params["flag"].value) is True
+
+
+def test_tools_call_backend_serializes_sdk_models() -> None:
+    client = _mock_client(_AliasModel(camelCaseField="value"))
+    backend = ToolsCallBackend("Code Search")
+
+    result = backend.execute(client, {"query": "x"})
+
+    assert result == {"camelCaseField": "value"}
+
+
+def test_tools_call_backend_truncates_large_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MAX_RESULT_CHARS_ENV, "50")
+    client = _mock_client({"blob": "x" * 200})
+    backend = ToolsCallBackend("Code Search")
+
+    result = backend.execute(client, {"query": "x"})
+
+    assert result["truncated"] is True
+    assert result["content"].endswith(TRUNCATION_MARKER)
+
+
+# ---------------------------------------------------------------------------
+# TypedBackend
+# ---------------------------------------------------------------------------
+
+
+def test_typed_backend_calls_fn_with_client_and_kwargs() -> None:
+    client = MagicMock()
+    seen: dict[str, Any] = {}
+
+    def fn(passed_client: Any, *, query: str, page_size: int = 10) -> dict[str, Any]:
+        seen["client"] = passed_client
+        seen["query"] = query
+        seen["page_size"] = page_size
+        return {"ok": True}
+
+    backend = TypedBackend(fn)
+
+    result = backend.execute(client, {"query": "hello", "page_size": 3})
+
+    assert result == {"ok": True}
+    assert seen == {"client": client, "query": "hello", "page_size": 3}
+
+
+def test_typed_backend_default_shaper_serializes_models() -> None:
+    backend = TypedBackend(lambda client: _AliasModel(camelCaseField="v"))
+
+    assert backend.execute(MagicMock(), {}) == {"camelCaseField": "v"}
+
+
+def test_typed_backend_custom_shaper_applied() -> None:
+    backend = TypedBackend(
+        lambda client: {"answer": 42},
+        shaper=lambda response: {"shaped": response["answer"]},
+    )
+
+    assert backend.execute(MagicMock(), {}) == {"shaped": 42}
+
+
+# ---------------------------------------------------------------------------
+# Registry and execute_tool dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scratch_registry(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Isolate registry mutations from the real tool registrations."""
+    scratch: dict[str, Any] = dict(_transport._BACKENDS)
+    monkeypatch.setattr(_transport, "_BACKENDS", scratch)
+    return scratch
+
+
+def test_register_and_get_backend(scratch_registry: dict[str, Any]) -> None:
+    backend = ToolsCallBackend("Scratch Tool")
+
+    returned = register_backend("scratch_tool", backend)
+
+    assert returned is backend
+    assert get_backend("scratch_tool") is backend
+
+
+def test_builtin_tools_all_registered() -> None:
+    expected = {
+        "glean_search",
+        "glean_web_search",
+        "glean_calendar_search",
+        "glean_employee_search",
+        "glean_code_search",
+        "glean_gmail_search",
+        "glean_outlook_search",
+        "glean_chat",
+        "glean_read_document",
+    }
+    import glean.agent_toolkit.tools  # noqa: F401  (registers all backends)
+
+    for name in expected:
+        assert get_backend(name) is not None, name
+
+
+def test_execute_tool_unknown_tool(scratch_registry: dict[str, Any]) -> None:
+    result = execute_tool("not_a_tool", {}, client=MagicMock())
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "validation"
+    assert result["suggested_action"] == "rephrase_query"
+    assert result["error"] is not None
+    assert "not_a_tool" in result["error"]
+
+
+def test_execute_tool_dispatches_to_backend(scratch_registry: dict[str, Any]) -> None:
+    client = MagicMock()
+    seen: dict[str, Any] = {}
+
+    class FakeBackend:
+        def execute(self, client: Any, arguments: Any) -> Any:
+            seen["client"] = client
+            seen["arguments"] = dict(arguments)
+            return {"payload": 1}
+
+    register_backend("fake_tool", FakeBackend())
+
+    result = execute_tool("fake_tool", {"a": 1}, client=client)
+
+    assert result == {
+        "status": "ok",
+        "result": {"payload": 1},
+        "error": None,
+        "error_type": None,
+        "suggested_action": None,
+    }
+    assert seen == {"client": client, "arguments": {"a": 1}}
+
+
+def test_execute_tool_creates_default_client(scratch_registry: dict[str, Any]) -> None:
+    seen: dict[str, Any] = {}
+
+    class FakeBackend:
+        def execute(self, client: Any, arguments: Any) -> Any:
+            seen["client"] = client
+            return "ok"
+
+    register_backend("fake_tool", FakeBackend())
+
+    result = execute_tool("fake_tool", {})
+
+    assert result["status"] == "ok"
+    assert seen["client"] is not None
+
+
+def test_execute_tool_classifies_backend_errors(scratch_registry: dict[str, Any]) -> None:
+    class FailingBackend:
+        def execute(self, client: Any, arguments: Any) -> Any:
+            raise ValueError("bad input")
+
+    register_backend("failing_tool", FailingBackend())
+
+    result = execute_tool("failing_tool", {}, client=MagicMock())
+
+    assert result["status"] == "error"
+    assert result["error"] == "bad input"
+    assert result["error_type"] == "validation"
+    assert result["suggested_action"] == "rephrase_query"


### PR DESCRIPTION
## Summary

One transport seam for all nine built-in tools: a tool's backend is now a declaration, not plumbing. This sets up the later opt-in experimental platform-API backend for search/chat as a config change instead of a multi-file edit.

### 1. Transport seam (`src/glean/agent_toolkit/tools/_transport.py`, private)

- `Backend` protocol with two implementations:
  - `ToolsCallBackend(display_name)` — wraps the assistant-UI `tools/call` path, including the `run`/`execute` method-name compat shim, argument→`ToolsCallParameter` coercion, and the result-size cap.
  - `TypedBackend(fn, shaper=None)` — typed SDK calls; `fn(client, **arguments)` performs the call, `shaper` produces the LLM-facing payload (default: `serialize_tool_result`).
- Single registry `tool name → backend instance`; each tool module registers its backend at import. `execute_tool(tool_name, arguments, client=None)` is the one place that resolves the client, dispatches, wraps `ToolResult`, and classifies errors.
- `run_tool` in `_common.py` remains as a legacy shim delegating to `ToolsCallBackend.call_raw`, so the `tools/call` plumbing exists exactly once.
- Public contract unchanged: tool function signatures, tool names, and the `ToolResult` envelope are untouched.
- Backends per tool: `glean_search`, `glean_chat`, `glean_read_document` → `TypedBackend`; the other six (`web_search`, `calendar_search`, `employee_search`, `code_search`, `gmail_search`, `outlook_search`) → `ToolsCallBackend`.

### 2. `glean_search` on the typed endpoint

Now calls `client.client.search.query(...)` (`POST /rest/api/v1/search`, glean-api-client 0.15.3).

Request mapping:

| Tool param | Typed request |
| --- | --- |
| `query` | `query` |
| `page_size` | `pageSize` |
| `datasources` | `requestOptions.datasourcesFilter` |
| `filters[i].field` | `requestOptions.facetFilters[i].fieldName` |
| `filters[i].values` | `facetFilters[i].values[*].value` (values within one filter are OR-ed; separate filters AND-ed) |
| `filters[i].exclude` | `values[*].relationType` = `NOT_EQUALS` when true, `EQUALS` otherwise — **`exclude` IS expressible**, nothing is dropped |

`requestOptions` is omitted entirely when neither datasources nor filters are given; `facetBucketSize=0` is sent (required field; we don't consume facet aggregations). A filter missing `field`/`values` raises → classified `validation`/`rephrase_query`.

Response shaping (replaces the raw UI blob):

```json
{
  "results": [{"title", "url", "snippets": ["..."], "datasource", "document_id"}],
  "result_count": <returned count>,
  "has_more_results": <bool>
}
```

- Snippets prefer the SDK's `text` field, falling back to the deprecated `snippet`; each snippet is capped at 500 chars with `...`.
- The `SearchResponse` carries no total-hit statistics; `result_count` is the returned count and the tool description says so (the old description advertised a `"statistics"` field that only existed in UI blobs — removed).
- Dead `_build_search_params` + its TODO deleted.

### 3. Generic truncation for tools-call results

Applied in `ToolsCallBackend` only: if the JSON serialization of the payload exceeds the cap, the result payload becomes `{"truncated": true, "max_chars", "note", "content": "<capped serialization>[truncated]"}`.

- Default cap: **40,000 chars**; override with `GLEAN_TOOL_MAX_RESULT_CHARS` (≤ 0 disables; non-integer falls back to default).
- Envelope keys unchanged; the marker lives inside `result`.

### 4. Status-code error classification

`_classify_error` now branches first on `glean.api_client.errors.GleanBaseError.status_code`:

| Status | error_type | suggested_action |
| --- | --- | --- |
| 401 / 403 | auth | check_credentials |
| 404 | not_found | rephrase_query |
| 408, httpx timeout classes, `TimeoutError` | timeout | retry |
| 429 | rate_limit | retry |
| 400 / 422 | validation | rephrase_query |
| 5xx (and other 4xx) | api | retry |

String heuristics are preserved as the fallback for non-SDK exceptions; `error_type`/`suggested_action` vocabularies unchanged.

## Tests

- `tests/tools/test_search.py` rewritten against the typed endpoint (request mapping incl. `NOT_EQUALS` for `exclude`, shaping, snippet truncation, invalid-filter validation).
- Transport contracts, invocation matrix, and client-lifecycle tests moved from mocking `/rest/api/v1/tools/call` to `/rest/api/v1/search` for search; wire-shape assertions cover `requestOptions.datasourcesFilter` and `facetFilters` serialization.
- Framework invocation tests (LangChain/OpenAI/CrewAI/ADK) now patch the `execute_tool` seam instead of `run_tool`.
- New `tests/tools/test_transport.py`: backend dispatch, registry, argument coercion, truncation (marker, env override, disable, unserializable fallback), TypedBackend shaping.
- New classification table in `tests/tools/test_common.py` built from real `GleanError`/`GleanDataError` instances (11 status codes) plus httpx timeout classes; status code beats message heuristics.
- All other tools' tests pass unchanged. Full suite: **313 passed, 4 skipped**; lint clean; coverage 93% (`_transport.py` at 100%).

## Docs follow-ups (not in this PR — README/docs owned elsewhere)

- README/docs describing `glean_search` output should be updated to the new shaped payload (no more raw `rawResponse` blob or `statistics` field).
- Document `GLEAN_TOOL_MAX_RESULT_CHARS` in the configuration/env-var docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)