### PR TITLE
test: add live end-to-end harness for tools and framework paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,61 @@
+name: E2E
+
+# Live end-to-end tests against a real Glean instance.
+#
+# Never triggered by pushes or pull requests: only manual dispatch and a
+# weekly cron. If the credential secrets (GLEAN_API_TOKEN plus
+# GLEAN_SERVER_URL or GLEAN_INSTANCE) are not configured, the job emits a
+# notice and exits green (no-op) instead of failing. See tests/e2e/README.md
+# for setup instructions.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 06:17 UTC (off-minute to avoid top-of-hour load spikes).
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Live E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Glean credentials
+        id: creds
+        env:
+          GLEAN_API_TOKEN: ${{ secrets.GLEAN_API_TOKEN }}
+          GLEAN_SERVER_URL: ${{ secrets.GLEAN_SERVER_URL }}
+          GLEAN_INSTANCE: ${{ secrets.GLEAN_INSTANCE }}
+        run: |
+          if [ -z "$GLEAN_API_TOKEN" ] || { [ -z "$GLEAN_SERVER_URL" ] && [ -z "$GLEAN_INSTANCE" ]; }; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Glean credential secrets are not configured (need GLEAN_API_TOKEN plus GLEAN_SERVER_URL or GLEAN_INSTANCE); skipping the live E2E run. See tests/e2e/README.md for setup (gh secret set ...)."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.creds.outputs.available == 'true'
+
+      - name: Set up mise
+        if: steps.creds.outputs.available == 'true'
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup development environment
+        if: steps.creds.outputs.available == 'true'
+        run: mise run setup
+
+      - name: Run live e2e tests
+        if: steps.creds.outputs.available == 'true'
+        env:
+          GLEAN_E2E: "1"
+          GLEAN_API_TOKEN: ${{ secrets.GLEAN_API_TOKEN }}
+          GLEAN_SERVER_URL: ${{ secrets.GLEAN_SERVER_URL }}
+          GLEAN_INSTANCE: ${{ secrets.GLEAN_INSTANCE }}
+        run: mise run test:e2e

--- a/mise.toml
+++ b/mise.toml
@@ -23,8 +23,12 @@ run = [
 ]
 
 [tasks.test]
-description = "Run unit tests"
-run = "uv run pytest -v --tb=auto -rA --durations=10 -p no:logging tests/"
+description = "Run unit tests (excludes live e2e tests; see test:e2e)"
+run = "uv run pytest -v --tb=auto -rA --durations=10 -p no:logging --ignore=tests/e2e tests/"
+
+[tasks."test:e2e"]
+description = "Run live end-to-end tests against a real Glean instance. Requires GLEAN_E2E=1 (explicit opt-in) plus GLEAN_API_TOKEN and GLEAN_SERVER_URL (or GLEAN_INSTANCE); tests skip with a reason otherwise. See tests/e2e/README.md"
+run = "uv run pytest -v --tb=auto -rA -p no:logging tests/e2e/"
 
 [tasks."test:watch"]
 description = "Run tests in watch mode"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,100 @@
+# Live end-to-end tests
+
+Everything else in `tests/` mocks the HTTP layer. This directory is the one
+place that hits a **real Glean instance**, exercising the full stack: tool
+functions, the transport seam, the `glean-api-client` SDK, real auth, and the
+framework adapters' native invocation paths.
+
+## Opt-in gate
+
+E2E tests are **skipped** (never failed) unless *all* of the following are set:
+
+| Variable | Purpose |
+| --- | --- |
+| `GLEAN_API_TOKEN` | Client API token for the target instance |
+| `GLEAN_SERVER_URL` *or* `GLEAN_INSTANCE` | Which instance to hit (`GLEAN_SERVER_URL` e.g. `https://<instance>-be.glean.com`, or the bare instance name via `GLEAN_INSTANCE`) |
+| `GLEAN_E2E=1` | Explicit opt-in. Required so a developer with real credentials exported in their shell cannot accidentally hit a live instance by running the normal suite. |
+
+The gate is enforced in `tests/e2e/conftest.py`, which also registers the
+`e2e` marker via `pytest_configure` (kept out of `pyproject.toml` on purpose)
+and overrides the repo-wide fixture that fakes Glean credentials.
+
+`mise run test` passes `--ignore=tests/e2e`, so the normal suite never even
+collects these tests. Other tasks that collect them (e.g. `test:cov`) are
+still safe: without `GLEAN_E2E=1` every test skips.
+
+## Running locally
+
+```bash
+export GLEAN_API_TOKEN="<client-api-token>"
+export GLEAN_INSTANCE="<instance>"          # or GLEAN_SERVER_URL=https://<instance>-be.glean.com
+
+GLEAN_E2E=1 mise run test:e2e
+# or directly:
+GLEAN_E2E=1 uv run pytest -v tests/e2e/
+```
+
+## Skip vs. fail semantics
+
+A red e2e run must mean a **real regression**, not per-instance configuration
+drift. The built-in tools depend on server-side features and connectors (see
+`docs/prerequisites.md`), so `tests/e2e/_live.py` classifies live errors:
+
+| Outcome | Behavior |
+| --- | --- |
+| Gate not satisfied | SKIP with a one-line reason (missing creds or missing `GLEAN_E2E=1`) |
+| `error_type=auth` (401/403) | **FAIL loudly** — bad credentials invalidate the whole run |
+| `error_type=validation` / `not_found` (400/404/422) | SKIP with the server's reason — tool/feature not configured on this instance (e.g. Gmail/Outlook/web search disabled, unknown `tools/call` name) |
+| `tools/call` 200 with a tool-level `error` in the body | SKIP with the server's reason |
+| `error_type=rate_limit` (429, retries exhausted) | SKIP — flagged as likely QA contention (see below), not a regression |
+| `error_type=api` / `timeout` (5xx, transport) | FAIL — real server/transport problem |
+
+The deliberate-bad-token test (`test_error_paths_live.py`) inverts this: it
+asserts that a real 401/403 is classified as
+`error_type=auth` / `suggested_action=check_credentials`.
+
+## Shared test instance realities
+
+The repo secrets target `salessavvy-test`, QA's release-qualification
+instance (the same one `gleanwork/connector-mcp` and `langchain-glean` test
+against). Three things follow:
+
+- **Contention / 429s**: QA runs post-deploy-validation sweeps after every
+  release deploy, so expect 429s and latency spikes in contention windows.
+  The suite defaults to generous built-in retry settings (`GLEAN_RETRY_*`
+  envs, applied in `conftest.py`; your own values win). If retries are still
+  exhausted, the test SKIPs with a message calling out contention.
+- **Token revocation**: Glean-issued user tokens are revoked when the backing
+  test user is signed out of all sessions (revocation cache). If CI suddenly
+  fails with auth errors, the token may have been revoked — re-mint it and
+  update the secret. The auth failure message calls this out.
+- **Version skew**: `salessavvy-test` runs release-candidate builds. A live
+  failure can therefore also mean an **upcoming-release regression** — that
+  is signal, not noise, and worth reporting even if the toolkit itself is
+  unchanged.
+
+## Artifact hygiene
+
+The suite is read-mostly. The only built-in that creates server-side
+artifacts is `glean_chat` (a chat session); its message is prefixed with the
+CI sentinel `gat-e2e-ci` per QA convention so test artifacts are identifiable
+and sweepable. Any future test that creates artifacts must use the same
+prefix in queries/titles.
+
+## CI
+
+`.github/workflows/e2e.yml` runs on `workflow_dispatch` and a weekly cron.
+It is never triggered by pushes or PRs. If the repo secrets are not
+configured, the job emits a notice and exits green (no-op) instead of
+failing.
+
+To configure the secrets:
+
+```bash
+gh secret set GLEAN_API_TOKEN --body "<client-api-token>"
+gh secret set GLEAN_INSTANCE --body "salessavvy-test"
+# or, instead of GLEAN_INSTANCE:
+gh secret set GLEAN_SERVER_URL --body "https://<instance>-be.glean.com"
+```
+
+Use a token scoped to a low-privilege test user on a non-production instance.

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Live end-to-end tests against a real Glean instance (opt-in, see conftest.py)."""

--- a/tests/e2e/_live.py
+++ b/tests/e2e/_live.py
@@ -1,0 +1,87 @@
+"""Shared helpers for the live e2e suite.
+
+The central design decision lives in :func:`unwrap_ok_or_skip`: a red e2e run
+must mean a real regression, not per-instance configuration drift. Built-in
+tools depend on server-side features and connectors (see
+docs/prerequisites.md), so when the live API reports a tool/feature as
+unavailable we SKIP with the server's reason. Auth failures and unexpected
+server/transport errors FAIL loudly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+TOOL_RESULT_KEYS = frozenset({"status", "result", "error", "error_type", "suggested_action"})
+
+# Error classifications that indicate the instance does not have the
+# feature/tool configured (unknown tools/call name, disabled endpoints,
+# unconfigured connectors surface as 400/404/422) rather than a toolkit bug.
+_FEATURE_UNAVAILABLE_ERROR_TYPES = frozenset({"validation", "not_found"})
+
+
+def assert_tool_result_envelope(result: Any) -> None:
+    """Assert *result* is a well-formed ``ToolResult`` envelope."""
+    assert isinstance(result, dict), f"expected ToolResult dict, got {type(result)!r}"
+    assert set(result) == TOOL_RESULT_KEYS, f"unexpected ToolResult keys: {sorted(result)}"
+    assert result["status"] in ("ok", "error")
+    if result["status"] == "ok":
+        assert result["error"] is None
+        assert result["error_type"] is None
+        assert result["suggested_action"] is None
+    else:
+        assert result["result"] is None
+        assert result["error"]
+
+
+def unwrap_ok_or_skip(result: Any, tool_name: str) -> Any:
+    """Return the success payload, or skip/fail based on the error class.
+
+    - ``status == "ok"``: return ``result["result"]``.
+    - ``error_type == "auth"``: FAIL loudly (bad credentials are never
+      instance config drift; the whole run is meaningless).
+    - ``error_type`` in validation/not_found: SKIP with the server's reason
+      (tool or feature not configured on this instance).
+    - ``error_type == "rate_limit"``: SKIP (transient, not a regression).
+    - anything else (api/timeout): FAIL (real server or transport problem).
+    """
+    assert_tool_result_envelope(result)
+
+    if result["status"] == "ok":
+        return result["result"]
+
+    error_type = result["error_type"]
+    error = result["error"]
+
+    if error_type == "auth":
+        pytest.fail(
+            f"{tool_name}: authentication failure against live instance "
+            f"(check GLEAN_API_TOKEN / GLEAN_SERVER_URL / GLEAN_INSTANCE; Glean-issued "
+            f"user tokens are revoked when the backing test user is signed out of all "
+            f"sessions -- the token may need to be re-minted): {error}"
+        )
+    if error_type in _FEATURE_UNAVAILABLE_ERROR_TYPES:
+        pytest.skip(f"{tool_name}: unavailable on this instance ({error_type}): {error}")
+    if error_type == "rate_limit":
+        pytest.skip(
+            f"{tool_name}: rate-limited by live instance even after retries "
+            f"(likely QA post-deploy-validation contention on the shared test "
+            f"instance, not a toolkit regression): {error}"
+        )
+
+    pytest.fail(f"{tool_name}: live call failed ({error_type}): {error}")
+
+
+def skip_if_tools_call_payload_error(payload: Any, tool_name: str) -> None:
+    """Skip when a 200-level ``tools/call`` payload carries a tool-level error.
+
+    The assistant-UI ``tools/call`` endpoint can respond 200 with an ``error``
+    field in the body when the underlying tool is disabled or misconfigured
+    for the instance; that is config drift, not a toolkit regression.
+    """
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if error:
+            pytest.skip(f"{tool_name}: server reported a tool-level error: {error}")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,109 @@
+"""Gating, marker registration, and fixtures for the live e2e suite.
+
+These tests hit a REAL Glean instance. They never run unless the caller
+explicitly opts in:
+
+- ``GLEAN_API_TOKEN`` must be set, AND
+- ``GLEAN_SERVER_URL`` or ``GLEAN_INSTANCE`` must be set, AND
+- ``GLEAN_E2E=1`` must be set (explicit opt-in so a developer with real
+  credentials in their shell cannot hit a live instance by accident when
+  running the normal suite).
+
+When the gate is closed every test in this directory is skipped with a
+one-line reason explaining what is missing.
+
+The ``e2e`` marker is registered here (not in pyproject.toml) via
+``pytest_configure`` so it satisfies ``--strict-markers``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+_E2E_DIR = Path(__file__).parent.resolve()
+
+
+def _gate_skip_reason() -> str | None:
+    """Return a one-line skip reason when the live-e2e gate is closed, else None."""
+    missing: list[str] = []
+    if not os.environ.get("GLEAN_API_TOKEN"):
+        missing.append("GLEAN_API_TOKEN")
+    if not (os.environ.get("GLEAN_SERVER_URL") or os.environ.get("GLEAN_INSTANCE")):
+        missing.append("GLEAN_SERVER_URL (or GLEAN_INSTANCE)")
+
+    if missing:
+        return f"e2e: missing live credentials: {', '.join(missing)}; also requires GLEAN_E2E=1"
+
+    if os.environ.get("GLEAN_E2E") != "1":
+        return (
+            "e2e: credentials present but GLEAN_E2E=1 not set "
+            "(explicit opt-in required before hitting a live Glean instance)"
+        )
+
+    return None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ``e2e`` marker (pyproject registration is intentionally avoided)."""
+    config.addinivalue_line(
+        "markers",
+        "e2e: live end-to-end test against a real Glean instance "
+        "(requires GLEAN_E2E=1 plus GLEAN_API_TOKEN and GLEAN_SERVER_URL/GLEAN_INSTANCE)",
+    )
+
+
+def _is_e2e_item(item: pytest.Item) -> bool:
+    path = getattr(item, "path", None)
+    if path is None:  # pragma: no cover - pytest<7 fallback
+        path = Path(str(item.fspath))
+    try:
+        return _E2E_DIR in Path(path).resolve().parents
+    except (OSError, ValueError):  # pragma: no cover - defensive
+        return False
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Mark every test under tests/e2e as ``e2e`` and enforce the opt-in gate."""
+    reason = _gate_skip_reason()
+    skip_marker = pytest.mark.skip(reason=reason) if reason else None
+
+    for item in items:
+        if not _is_e2e_item(item):
+            continue
+        item.add_marker(pytest.mark.e2e)
+        if skip_marker is not None:
+            item.add_marker(skip_marker)
+
+
+@pytest.fixture(autouse=True)
+def mock_glean_env_vars() -> None:
+    """Override the repo-wide autouse fixture that fakes Glean credentials.
+
+    tests/conftest.py patches ``GLEAN_API_TOKEN``/``GLEAN_SERVER_URL`` to fake
+    values for the mocked unit suite. Live e2e tests must see the real
+    environment, so this no-op override shadows it for this directory.
+    """
+    return None
+
+
+# The shared QA test instance (salessavvy-test) runs release-qualification
+# sweeps after every deploy, so 429s and latency spikes are expected in
+# contention windows. Lean on the toolkit's built-in RetryConfig
+# (GLEAN_RETRY_* envs, seconds) with generous defaults instead of adding a
+# custom retry layer. Explicit values in the caller's environment win.
+_DEFAULT_RETRY_ENVS = {
+    "GLEAN_RETRY_INITIAL": "1",
+    "GLEAN_RETRY_MAX": "30",
+    "GLEAN_RETRY_MAX_ELAPSED": "120",
+}
+
+
+@pytest.fixture(autouse=True)
+def _generous_retry_envs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to generous GLEAN_RETRY_* settings for live calls (e2e dir only)."""
+    for name, value in _DEFAULT_RETRY_ENVS.items():
+        if not os.environ.get(name):
+            monkeypatch.setenv(name, value)

--- a/tests/e2e/test_error_paths_live.py
+++ b/tests/e2e/test_error_paths_live.py
@@ -1,0 +1,38 @@
+"""Live error-path e2e test: validate status-code classification against real responses.
+
+The unit suite asserts the 401/403 -> auth mapping against mocked responses;
+this test proves the classification holds for a REAL server rejection.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from glean.agent_toolkit.context import GleanContext
+from glean.agent_toolkit.tools import search
+from tests.e2e._live import assert_tool_result_envelope
+
+pytestmark = pytest.mark.e2e
+
+
+def test_bad_token_is_classified_as_auth_error() -> None:
+    """A deliberately invalid token must produce a structured auth error."""
+    server_url = os.environ.get("GLEAN_SERVER_URL")
+    instance = os.environ.get("GLEAN_INSTANCE")
+
+    if server_url:
+        ctx = GleanContext(api_token="invalid-token-for-e2e-error-path", server_url=server_url)
+    else:
+        ctx = GleanContext(api_token="invalid-token-for-e2e-error-path", instance=instance)
+
+    with ctx:
+        result = search(ctx, query="glean", page_size=1)
+
+    assert_tool_result_envelope(result)
+    assert result["status"] == "error", (
+        f"expected the live server to reject an invalid token, got: {result}"
+    )
+    assert result["error_type"] == "auth", result
+    assert result["suggested_action"] == "check_credentials", result

--- a/tests/e2e/test_frameworks_live.py
+++ b/tests/e2e/test_frameworks_live.py
@@ -1,0 +1,102 @@
+"""Live framework-path e2e tests: glean_search through each real framework layer.
+
+Drives the converted glean_search tool through every supported framework's
+native invocation path against the live Glean API. No LLM API keys are
+required -- these invoke the tool layer directly through framework plumbing:
+
+- LangChain: ``tool.invoke`` and ``tool.ainvoke``
+- OpenAI Agents SDK: ``tool.on_invoke_tool``
+- CrewAI: ``tool.run``
+- Google ADK: ``tool.run_async``
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from glean.agent_toolkit import get_tools
+from tests.e2e._live import unwrap_ok_or_skip
+
+try:
+    from glean.agent_toolkit.adapters.langchain import HAS_LANGCHAIN
+except ImportError:  # pragma: no cover
+    HAS_LANGCHAIN = False
+
+try:
+    from glean.agent_toolkit.adapters.openai import HAS_OPENAI
+except ImportError:  # pragma: no cover
+    HAS_OPENAI = False
+
+try:
+    from glean.agent_toolkit.adapters.crewai import HAS_CREWAI
+except ImportError:  # pragma: no cover
+    HAS_CREWAI = False
+
+try:
+    from glean.agent_toolkit.adapters.adk import HAS_ADK
+except ImportError:  # pragma: no cover
+    HAS_ADK = False
+
+pytestmark = pytest.mark.e2e
+
+SEARCH_ARGS: dict[str, Any] = {"query": "glean", "page_size": 3}
+SEARCH_PAYLOAD_KEYS = {"results", "result_count", "has_more_results"}
+
+
+def _get_search_tool(framework: str) -> Any:
+    tools = get_tools(framework, include=["glean_search"])
+    assert len(tools) == 1, f"glean_search missing from get_tools({framework!r})"
+    return tools[0]
+
+
+def _assert_live_search_result(tool_result: Any, framework_path: str) -> None:
+    payload = unwrap_ok_or_skip(tool_result, f"glean_search via {framework_path}")
+    assert isinstance(payload, dict)
+    assert set(payload) == SEARCH_PAYLOAD_KEYS
+    assert isinstance(payload["results"], list)
+    assert payload["result_count"] == len(payload["results"])
+
+
+@pytest.mark.skipif(not HAS_LANGCHAIN, reason="LangChain not installed")
+def test_langchain_invoke_live() -> None:
+    tool = _get_search_tool("langchain")
+    output = tool.invoke(dict(SEARCH_ARGS))
+    assert isinstance(output, str)
+    _assert_live_search_result(json.loads(output), "langchain invoke")
+
+
+@pytest.mark.skipif(not HAS_LANGCHAIN, reason="LangChain not installed")
+async def test_langchain_ainvoke_live() -> None:
+    tool = _get_search_tool("langchain")
+    output = await tool.ainvoke(dict(SEARCH_ARGS))
+    assert isinstance(output, str)
+    _assert_live_search_result(json.loads(output), "langchain ainvoke")
+
+
+@pytest.mark.skipif(not HAS_OPENAI, reason="OpenAI Agents SDK not installed")
+async def test_openai_on_invoke_tool_live() -> None:
+    tool = _get_search_tool("openai")
+    # The adapter ignores the SDK run context, so a stub suffices.
+    output = await tool.on_invoke_tool(SimpleNamespace(), json.dumps(SEARCH_ARGS))
+    assert isinstance(output, str)
+    _assert_live_search_result(json.loads(output), "openai on_invoke_tool")
+
+
+@pytest.mark.skipif(not HAS_CREWAI, reason="CrewAI not installed")
+def test_crewai_run_live() -> None:
+    tool = _get_search_tool("crewai")
+    output = tool.run(**SEARCH_ARGS)
+    assert isinstance(output, str)
+    _assert_live_search_result(json.loads(output), "crewai run")
+
+
+@pytest.mark.skipif(not HAS_ADK, reason="Google ADK not installed")
+async def test_adk_run_async_live() -> None:
+    tool = _get_search_tool("adk")
+    result = await tool.run_async(args=dict(SEARCH_ARGS), tool_context=None)
+    assert isinstance(result, dict)
+    _assert_live_search_result(result, "adk run_async")

--- a/tests/e2e/test_tools_live.py
+++ b/tests/e2e/test_tools_live.py
@@ -7,7 +7,8 @@ skip with the server's reason; auth failures fail loudly (see _live.py).
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 

--- a/tests/e2e/test_tools_live.py
+++ b/tests/e2e/test_tools_live.py
@@ -1,0 +1,121 @@
+"""Live tool-level e2e tests: every built-in tool invoked against a real Glean instance.
+
+Each test uses a cheap, deterministic-ish query and asserts the ToolResult
+envelope plus the shape of the success payload. Feature-unavailable responses
+skip with the server's reason; auth failures fail loudly (see _live.py).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+
+from glean.agent_toolkit.tools import (
+    calendar_search,
+    code_search,
+    employee_search,
+    glean_chat,
+    gmail_search,
+    outlook_search,
+    read_document,
+    search,
+    web_search,
+)
+from tests.e2e._live import skip_if_tools_call_payload_error, unwrap_ok_or_skip
+
+pytestmark = pytest.mark.e2e
+
+SEARCH_PAYLOAD_KEYS = {"results", "result_count", "has_more_results"}
+SEARCH_RESULT_ITEM_KEYS = {"title", "url", "snippets", "datasource", "document_id"}
+
+
+def _live_search(query: str = "glean", page_size: int = 5) -> dict[str, Any]:
+    """Run glean_search live and return the shaped payload (or skip/fail)."""
+    result = search(query=query, page_size=page_size)
+    payload = unwrap_ok_or_skip(result, "glean_search")
+    assert isinstance(payload, dict)
+    assert set(payload) == SEARCH_PAYLOAD_KEYS
+    return payload
+
+
+def test_search_live() -> None:
+    payload = _live_search()
+
+    assert isinstance(payload["results"], list)
+    assert payload["result_count"] == len(payload["results"])
+    assert isinstance(payload["has_more_results"], bool)
+    for item in payload["results"]:
+        assert set(item) == SEARCH_RESULT_ITEM_KEYS
+        assert isinstance(item["snippets"], list)
+
+
+# CI-sentinel prefix (QA convention on the shared test instance) for anything
+# that creates server-side artifacts. Chat is the only built-in that does
+# (it creates a chat session); everything else in this suite is read-only.
+E2E_SENTINEL = "gat-e2e-ci"
+
+
+def test_chat_live() -> None:
+    result = glean_chat(message=f"{E2E_SENTINEL}: In one short sentence, what is Glean used for?")
+    payload = unwrap_ok_or_skip(result, "glean_chat")
+
+    assert isinstance(payload, dict)
+    assert set(payload) == {"answer", "sources"}
+    assert isinstance(payload["answer"], str)
+    assert payload["answer"].strip(), "glean_chat returned an empty answer"
+    assert isinstance(payload["sources"], list)
+
+
+def test_read_document_live() -> None:
+    # Chain off a live search so the test adapts to whatever the instance indexes.
+    search_payload = _live_search(page_size=10)
+    document_ids = [
+        item["document_id"] for item in search_payload["results"] if item.get("document_id")
+    ]
+    if not document_ids:
+        pytest.skip("glean_read_document: live search returned no documents with IDs to read")
+
+    result = read_document(document_id=document_ids[0])
+    payload = unwrap_ok_or_skip(result, "glean_read_document")
+
+    assert isinstance(payload, dict)
+    documents = payload.get("documents")
+    if not documents:
+        pytest.skip(
+            "glean_read_document: server returned no document content "
+            "(queryapi.getDocuments may be disabled on this instance)"
+        )
+    assert isinstance(documents, dict)
+    assert len(documents) >= 1
+
+
+# Tools backed by the assistant-UI ``tools/call`` endpoint. Their payloads are
+# server-shaped blobs, so shape assertions are intentionally loose: a
+# non-empty dict with no tool-level error. Unknown/disabled tools surface as
+# 4xx (skip via unwrap_ok_or_skip) or a 200 with an ``error`` field (skip via
+# skip_if_tools_call_payload_error).
+TOOLS_CALL_CASES: list[tuple[str, Callable[..., Any], str]] = [
+    ("glean_employee_search", employee_search, "engineer"),
+    ("glean_web_search", web_search, "what is the capital of France"),
+    ("glean_calendar_search", calendar_search, "meeting"),
+    ("glean_code_search", code_search, "def main"),
+    ("glean_gmail_search", gmail_search, "meeting"),
+    ("glean_outlook_search", outlook_search, "meeting"),
+]
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_fn", "query"),
+    TOOLS_CALL_CASES,
+    ids=[case[0] for case in TOOLS_CALL_CASES],
+)
+def test_tools_call_backed_tool_live(
+    tool_name: str, tool_fn: Callable[..., Any], query: str
+) -> None:
+    result = tool_fn(query=query)
+    payload = unwrap_ok_or_skip(result, tool_name)
+
+    skip_if_tools_call_payload_error(payload, tool_name)
+    assert isinstance(payload, dict), f"{tool_name}: expected dict payload, got {type(payload)!r}"
+    assert payload, f"{tool_name}: expected a non-empty payload"


### PR DESCRIPTION
## Why

Everything in `tests/` mocks HTTP; nothing ever hit a real Glean instance. This adds an opt-in live E2E harness so integration regressions (auth, wire formats, SDK drift, framework plumbing) are caught against a real server.

## What

- **`tests/e2e/`** — live suite, gated and marker-registered in `tests/e2e/conftest.py` (`pytest_configure` + `pytest_collection_modifyitems`; `pyproject.toml` untouched, satisfies `--strict-markers`). The repo-wide fake-credential fixture is overridden for this directory.
- **`test_tools_live.py`** — all 9 built-ins with cheap queries; `read_document` chains off a live search for a real document ID.
- **`test_frameworks_live.py`** — `glean_search` through LangChain `invoke`/`ainvoke`, OpenAI `on_invoke_tool`, CrewAI `run`, ADK `run_async` against the live API (no LLM keys needed).
- **`test_error_paths_live.py`** — deliberately bad token must classify as `status=error`, `error_type=auth`, `suggested_action=check_credentials` against a real 401/403.
- **`mise run test:e2e`** — runs only `tests/e2e/`; `mise run test` now passes `--ignore=tests/e2e` so the normal suite never collects the live tests.
- **`.github/workflows/e2e.yml`** — `workflow_dispatch` + weekly cron (Mon 06:17 UTC). Never triggered by pushes/PRs. No-ops green with a `::notice` when secrets are unset.

## Gating semantics

| Condition | Result |
| --- | --- |
| `mise run test` (normal suite) | e2e never collected (`--ignore=tests/e2e`) |
| Missing `GLEAN_API_TOKEN` or `GLEAN_SERVER_URL`/`GLEAN_INSTANCE` | SKIP: `e2e: missing live credentials: ...` |
| Creds present but `GLEAN_E2E` != `1` | SKIP: explicit opt-in required (protects devs with creds in their shell) |
| Gate open, live `error_type=auth` (401/403) | **FAIL loudly** (token may have been revoked — re-mint) |
| Gate open, `validation`/`not_found` (400/404/422) or `tools/call` body-level error | SKIP with the server's reason (per-instance feature/config drift, see `docs/prerequisites.md`) |
| Gate open, `rate_limit` (429 after generous built-in retries) | SKIP, flagged as likely QA post-deploy contention on `salessavvy-test` |
| Gate open, `api`/`timeout` (5xx, transport) | FAIL — real server/transport problem (note: instance runs RC builds, so this can be an upcoming-release regression — signal, not noise) |

## Secrets setup (needed before CI runs do anything)

```bash
gh secret set GLEAN_API_TOKEN --body "<client-api-token>"
gh secret set GLEAN_INSTANCE --body "salessavvy-test"
# or instead of GLEAN_INSTANCE:
gh secret set GLEAN_SERVER_URL --body "https://<instance>-be.glean.com"
```

## Verified locally (no live creds in this environment)

- Full normal suite untouched and green: 313 passed, 4 skipped.
- No creds: all 15 e2e tests skip with `missing live credentials` reason.
- Creds (fake) + no `GLEAN_E2E`: all 15 skip with the opt-in reason (verified with both `GLEAN_SERVER_URL` and `GLEAN_INSTANCE`).
- `pytest tests/` (e2e collected, as `test:cov` would): 313 passed, 19 skipped — strict-markers happy, no accidental live calls.
- `ruff check`/`format` and `pyright` clean on `tests/e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)