### PR TITLE
feat: raw adapter results, fail-fast config errors, configure(), builtin-only get_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,13 @@
 # Glean Agent Toolkit
 
-The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and knowledge discovery capabilities into your AI agents. Use our pre-built tools with popular agent frameworks like OpenAI Assistants, LangChain, CrewAI, and Google's Agent Development Kit (ADK), or adapt your own custom tools for cross-framework use.
+The Glean Agent Toolkit makes it easy to integrate Glean's powerful search and knowledge discovery capabilities into your AI agents. Use our pre-built tools with popular agent frameworks like OpenAI Agents SDK, LangChain, CrewAI, and Google's Agent Development Kit (ADK), or adapt your own custom tools for cross-framework use.
 
 ## Key Features
 
 - **Production-Ready Glean Tools:** Instantly add capabilities like enterprise search, employee lookup, calendar search, Gmail search, and more to your agents.
 - **Framework Adapters:** Seamlessly convert Glean tools into formats compatible with major agent SDKs.
+- **Native Async:** Every built-in tool has a native async path — no hidden thread pools.
 - **Custom Tool Creation:** Define your own tools once using the `@tool_spec` decorator and use them across any supported framework.
-
-## Compatibility & Reliability
-
-- Requires Python 3.10+
-- Built-in retries are enabled via the Python client’s `RetryConfig`.
-- See `docs/prerequisites.md` for server-level configuration and connector requirements.
-
-### Retry configuration (env vars)
-
-| Variable                  | Default | Description                                              | Example |
-| ------------------------- | ------- | -------------------------------------------------------- | ------- |
-| `GLEAN_RETRY_INITIAL`     | `1.0`   | Initial backoff interval in seconds                      | `0.5`   |
-| `GLEAN_RETRY_MAX`         | `50.0`  | Maximum backoff interval in seconds                      | `8`     |
-| `GLEAN_RETRY_MULTIPLIER`  | `1.1`   | Backoff multiplier/exponent                              | `2.0`   |
-| `GLEAN_RETRY_MAX_ELAPSED` | `60.0`  | Total time limit in seconds before giving up on retries  | `30`    |
-
-Intervals are expressed in seconds and may be fractional (e.g. `0.5`); the multiplier is a unitless exponent. Retries cover transient failures such as HTTP 429/5xx and connection timeouts. Set these before constructing any Glean client usage.
-
-```bash
-# Example: low-latency, bounded retries
-export GLEAN_RETRY_INITIAL=0.5
-export GLEAN_RETRY_MAX=8
-export GLEAN_RETRY_MULTIPLIER=2.0
-export GLEAN_RETRY_MAX_ELAPSED=30
-```
 
 ## Installation
 
@@ -64,23 +40,413 @@ pip install glean-agent-toolkit[langchain]
 pip install glean-agent-toolkit[crewai]
 ```
 
-Note: The `[openai]` extra installs both the standard `openai` Python library (for direct API interactions like Chat Completions) and the `openai-agents` library used by the "OpenAI Agents SDK" example below — no separate install is needed.
+Note: The `[openai]` extra installs both the standard `openai` Python library (for direct API interactions like Chat Completions) and the `openai-agents` library used by the "OpenAI Agents SDK" examples below — no separate install is needed.
 
-## Prerequisites
+## Quickstart
 
-Before using any Glean tools, you'll need:
+Set your Glean credentials (get them from your Glean administrator):
 
-1. **Glean API credentials**: Obtain these from your Glean administrator
-2. **Environment variables**:
+```bash
+export GLEAN_API_TOKEN="your-api-token"
+export GLEAN_SERVER_URL="https://your-company-be.glean.com"
+```
 
-   ```bash
-   export GLEAN_API_TOKEN="your-api-token"
-   export GLEAN_SERVER_URL="https://your-company-be.glean.com"
-   ```
+`GLEAN_SERVER_URL` must be a full URL including the `https://` scheme (a bare hostname is rejected immediately with a clear error). You can use `GLEAN_INSTANCE="your-company"` instead of `GLEAN_SERVER_URL`.
 
-See `docs/prerequisites.md` for instance-level connector and Admin settings required per tool.
+Then one call gives you the full bundle of built-in Glean tools, converted for your framework.
 
-## Quickstart Example: Company Assistant with Google ADK
+### LangChain
+
+```python snippet=readme/snippet-11.py
+from glean.agent_toolkit import get_tools
+
+# The nine built-in Glean tools, converted to LangChain StructuredTools.
+# Credentials are read from GLEAN_API_TOKEN and GLEAN_SERVER_URL.
+tools = get_tools("langchain")
+
+# Bind them to any LangChain / LangGraph agent, e.g.:
+#   from langgraph.prebuilt import create_react_agent
+#   agent = create_react_agent(llm, tools)
+print([tool.name for tool in tools])
+```
+
+### OpenAI Agents SDK
+
+```python snippet=readme/snippet-12.py
+from agents import Agent, Runner
+
+from glean.agent_toolkit import get_tools
+
+agent = Agent(
+    name="KnowledgeAssistant",
+    instructions="Answer questions using Glean enterprise search.",
+    tools=get_tools("openai"),
+)
+
+result = Runner.run_sync(agent, "Find our Q4 planning documents")
+print(result.final_output)
+```
+
+`get_tools()` accepts `"openai"`, `"langchain"`, `"crewai"`, and `"adk"`, and can be scoped with `include=`/`exclude=`:
+
+```python
+from glean.agent_toolkit import get_tools
+
+langchain_tools = get_tools("langchain")
+openai_tools = get_tools("openai", include=["glean_search", "glean_chat"])
+```
+
+By default `get_tools()` returns exactly the nine built-in Glean tools. Custom tools you register with `@tool_spec` require explicit opt-in: `builtin=False` for custom tools only, `builtin=None` for everything in the registry, or list them via `include=` (explicitly included tools always win).
+
+## Configuration
+
+### `configure()` — process-wide defaults
+
+Instead of environment variables, you can set credentials once with `configure()`. Every tool call, adapter, and `get_tools()` call made without explicit credentials uses these defaults (and shares one underlying HTTP client):
+
+```python snippet=readme/snippet-13.py
+import glean.agent_toolkit
+
+glean.agent_toolkit.configure(
+    api_token="your-api-token",
+    server_url="https://your-company-be.glean.com",  # or instance="your-company"
+)
+
+tools = glean.agent_toolkit.get_tools("langchain")
+```
+
+`configure()` is idempotent (calling it again replaces the defaults) and always overridable per call: explicit `api_token=`/`server_url=`/`client=` arguments to `get_tools()` or an explicit `GleanContext` passed to a tool win over the configured defaults. Passing `client=` lets you supply a pre-built `glean.api_client.Glean` client.
+
+### Retry configuration (env vars)
+
+Built-in retries are enabled via the Python client's `RetryConfig`. Retries cover transient failures such as HTTP 429/5xx and connection timeouts.
+
+| Variable                  | Default | Description                                              | Example |
+| ------------------------- | ------- | -------------------------------------------------------- | ------- |
+| `GLEAN_RETRY_INITIAL`     | `1.0`   | Initial backoff interval in seconds                      | `0.5`   |
+| `GLEAN_RETRY_MAX`         | `50.0`  | Maximum backoff interval in seconds                      | `8`     |
+| `GLEAN_RETRY_MULTIPLIER`  | `1.1`   | Backoff multiplier/exponent                              | `2.0`   |
+| `GLEAN_RETRY_MAX_ELAPSED` | `60.0`  | Total time limit in seconds before giving up on retries  | `30`    |
+
+Intervals are expressed in seconds and may be fractional (e.g. `0.5`); the multiplier is a unitless exponent. Set these before constructing any Glean client usage.
+
+```bash
+# Example: low-latency, bounded retries
+export GLEAN_RETRY_INITIAL=0.5
+export GLEAN_RETRY_MAX=8
+export GLEAN_RETRY_MULTIPLIER=2.0
+export GLEAN_RETRY_MAX_ELAPSED=30
+```
+
+Note: connection errors (unreachable or unresolvable hosts) are also retried for up to `GLEAN_RETRY_MAX_ELAPSED` seconds before failing — if a misconfigured `server_url` seems to "hang", that is the retry budget. The resulting error is classified as `config` (see the error table below) and carries this hint.
+
+See `docs/prerequisites.md` for server-level configuration and connector requirements. Requires Python 3.10+.
+
+## Available Tools
+
+| Tool name                | Import name         | Description                                    |
+| ------------------------ | ------------------- | ---------------------------------------------- |
+| `glean_search`           | `search`            | Search internal documents and knowledge bases  |
+| `glean_chat`             | `chat`              | Conversational Q&A with Glean Assistant        |
+| `glean_read_document`    | `read_document`     | Read full document content by ID or URL        |
+| `glean_web_search`       | `web_search`        | Search the public web for external information |
+| `glean_calendar_search`  | `calendar_search`   | Find meetings and calendar events              |
+| `glean_employee_search`  | `employee_search`   | Search employees by name, team, or department  |
+| `glean_code_search`      | `code_search`       | Search source code repositories                |
+| `glean_gmail_search`     | `gmail_search`      | Search Gmail messages and conversations        |
+| `glean_outlook_search`   | `outlook_search`    | Search Outlook mail and calendar items         |
+
+### Explicit imports
+
+```python
+from glean.agent_toolkit.tools import search, chat, read_document
+from glean.agent_toolkit.tools import web_search, calendar_search
+from glean.agent_toolkit.tools import employee_search, code_search
+from glean.agent_toolkit.tools import gmail_search, outlook_search
+```
+
+Note: the chat tool's import name is `chat` (the tool ID exposed to LLMs remains `glean_chat`). The old `glean_chat` import name still works but is deprecated and emits a `DeprecationWarning`.
+
+### Adapter methods
+
+Each tool function exposes adapter methods for framework conversion:
+
+| Method                | Returns                          | Framework           |
+| --------------------- | -------------------------------- | ------------------- |
+| `.as_openai_tool()`   | `FunctionTool` or `dict`         | OpenAI Agents SDK   |
+| `.as_langchain_tool()` | `langchain_core.tools.StructuredTool` | LangChain / LangGraph |
+| `.as_crewai_tool()`   | `CrewAI BaseTool`                | CrewAI              |
+| `.as_adk_tool()`      | `google.adk FunctionTool`        | Google ADK          |
+
+## Tool Results and Error Handling
+
+### Direct Python calls: the `ToolResult` envelope
+
+Calling a tool function directly always returns a structured `ToolResult` dict — errors (including missing credentials) never raise:
+
+```python
+from glean.agent_toolkit.tools import search
+
+result = search(query="quarterly results")
+# {
+#     "status": "ok" | "error",
+#     "result": <payload> | None,
+#     "error": <message> | None,
+#     "error_type": <classification> | None,
+#     "suggested_action": <hint> | None,
+# }
+if result["status"] == "ok":
+    payload = result["result"]
+else:
+    print(result["error_type"], result["error"])
+```
+
+### Through framework adapters: raw results
+
+Framework adapters (`get_tools()`, `.as_*_tool()`) unwrap the envelope before handing results to the framework, so the LLM sees clean payloads:
+
+- On success the adapter delivers the **raw `result` payload** (JSON-serialized where the framework expects a string — LangChain, OpenAI Agents SDK, CrewAI; as a plain object for ADK).
+- On failure the adapter delivers a compact error dict: `{"error": ..., "error_type": ..., "suggested_action": ...}`.
+
+Custom `@tool_spec` tools that do not return a `ToolResult` envelope pass through the adapters unchanged.
+
+### Error types
+
+| `error_type`   | Meaning                                                | `suggested_action`      |
+| -------------- | ------------------------------------------------------ | ----------------------- |
+| `"auth"`       | 401/403, or missing API token/credentials              | `"check_credentials"`   |
+| `"config"`     | Invalid `server_url`, unreachable or unresolvable host | `"check_configuration"` |
+| `"validation"` | Bad input (400/422, invalid arguments)                 | `"rephrase_query"`      |
+| `"not_found"`  | 404 — resource not found                               | `"rephrase_query"`      |
+| `"timeout"`    | Request timed out                                      | `"retry"`               |
+| `"rate_limit"` | 429 — too many requests                                | `"retry"`               |
+| `"api"`        | Other API/transport error                              | `"retry"`               |
+
+## Async Usage
+
+Built-in tools are natively async end to end: framework async invocation flows through the Glean SDK's async HTTP client with no thread-pool round-trip.
+
+```python snippet=readme/snippet-14.py
+import asyncio
+
+from glean.agent_toolkit import get_tools
+
+
+async def main() -> None:
+    """Run glean_search through LangChain's native async path."""
+    (search_tool,) = get_tools("langchain", include=["glean_search"])
+    output = await search_tool.ainvoke({"query": "quarterly results", "page_size": 5})
+    print(output)
+
+
+asyncio.run(main())
+```
+
+The OpenAI Agents SDK and Google ADK adapters are async-first automatically; CrewAI uses the sync path.
+
+For direct async calls, every decorated tool exposes an `async_function` on its spec:
+
+```python
+from glean.agent_toolkit.tools import search
+
+result = await search.tool_spec.async_function(query="roadmap")
+```
+
+### Async custom tools
+
+`@tool_spec` accepts `async def` functions; the coroutine becomes the native async path:
+
+```python
+from glean.agent_toolkit import tool_spec
+
+
+@tool_spec(name="fetch_status", description="Fetch service status")
+async def fetch_status(service: str) -> dict:
+    ...  # await your async client here
+```
+
+Caveat: calling an `async def` tool synchronously (e.g. `fetch_status.tool_spec.function(...)` or via a sync-only framework path) works outside an event loop via a sync bridge (`asyncio.run`), but raises a clear `RuntimeError` when invoked from *inside* a running event loop — use the async path (`await`, `ainvoke`, `run_async`) there instead.
+
+## Framework Examples
+
+### OpenAI Agents SDK
+
+```python snippet=readme/snippet-03.py
+import os
+
+from agents import Agent, Runner
+
+from glean.agent_toolkit.tools import search
+
+# Ensure environment variables are set
+assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
+assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
+assert os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY must be set"
+
+# Create an agent with the Glean search tool
+agent = Agent(
+    name="KnowledgeAssistant",
+    instructions="""You help users find information from the company knowledge base using
+    Glean search.""",
+    tools=[search.as_openai_tool()],  # Convert to an Agents SDK FunctionTool
+)
+
+# Run a search query
+result = Runner.run_sync(agent, "Find our Q4 planning documents")
+print(f"Search results: {result.final_output}")
+```
+
+### LangChain
+
+```python snippet=readme/snippet-04.py
+import os
+
+# NOTE: AgentExecutor requires the full `langchain` package (not just langchain-core).
+# Install with: pip install langchain
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+from glean.agent_toolkit.tools import search
+
+# Ensure environment variables are set
+assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
+assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
+
+# Convert to LangChain tool format
+langchain_tool = search.as_langchain_tool()
+
+llm = ChatOpenAI(model="gpt-4", temperature=0)
+tools = [langchain_tool]
+
+prompt_template = """You are a helpful assistant with access to company knowledge.
+Use the search tool to find relevant information when users ask questions.
+
+Tools available:
+{tools}
+
+Use this format:
+Question: {input}
+Thought: I should search for information about this topic
+Action: {tool_names}
+Action Input: your search query
+Observation: the search results
+Thought: I can now provide a helpful response
+Final Answer: your response based on the search results
+
+Question: {input}
+{agent_scratchpad}"""
+
+prompt = ChatPromptTemplate.from_template(prompt_template)
+agent = create_react_agent(llm, tools, prompt)
+agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+
+# Search for company information
+result = agent_executor.invoke({"input": "What is our vacation policy?"})
+print(result["output"])
+```
+
+### CrewAI
+
+```python snippet=readme/snippet-05.py
+import os
+
+from crewai import Agent, Crew, Task
+
+from glean.agent_toolkit.tools import search
+
+# Ensure environment variables are set
+assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
+assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
+
+# Convert to CrewAI tool format
+crewai_tool = search.as_crewai_tool()
+
+# Create a research agent
+researcher = Agent(
+    role="Corporate Knowledge Researcher",
+    goal="Find and summarize relevant company information",
+    backstory="""You are an expert at navigating company knowledge bases to find accurate,
+    up-to-date information.""",
+    tools=[crewai_tool],
+    verbose=True,
+)
+
+# Create a research task
+research_task = Task(
+    description="""Find information about our company's remote work policy and summarize the key
+    points.""",
+    expected_output="""A clear summary of the remote work policy including eligibility,
+    expectations, and guidelines.""",
+    agent=researcher,
+)
+
+# Execute the research
+crew = Crew(agents=[researcher], tasks=[research_task])
+result = crew.kickoff()
+print(result)
+```
+
+### Real-World Use Cases
+
+#### Employee Directory Search
+
+```python snippet=readme/snippet-06.py
+from glean.agent_toolkit.tools import employee_search
+
+# Find engineering team members
+engineering_team = employee_search.as_langchain_tool()
+
+# Example usage in an agent:
+# "Who are the senior engineers in the backend team?"
+# "Find Sarah Johnson's contact information"
+# "List all product managers in the San Francisco office"
+```
+
+#### Code Discovery
+
+```python snippet=readme/snippet-07.py
+from glean.agent_toolkit.tools import code_search
+
+# Search company codebases
+code_tool = code_search.as_langchain_tool()
+
+# Example queries:
+# "Find authentication middleware implementations"
+# "Show me recent changes to the payment processing module"
+# "Locate configuration files for the staging environment"
+```
+
+#### Email and Calendar Integration
+
+```python snippet=readme/snippet-08.py
+from glean.agent_toolkit.tools import calendar_search, gmail_search
+
+# Search emails and meetings
+gmail_tool = gmail_search.as_langchain_tool()
+calendar_tool = calendar_search.as_langchain_tool()
+
+# Example queries:
+# "Find emails about the product launch from last month"
+# "Show me my meetings with the design team this week"
+# "Search for messages containing budget discussions"
+```
+
+#### Web Research with Context
+
+```python snippet=readme/snippet-09.py
+from glean.agent_toolkit.tools import web_search
+
+# External information gathering
+web_tool = web_search.as_langchain_tool()
+
+# Example queries:
+# "Latest industry trends in machine learning"
+# "Current market analysis for SaaS companies"
+# "Recent news about our competitors"
+```
+
+## Walkthrough: Company Assistant with Google ADK
 
 Here's a complete example that demonstrates the power of the Glean Agent Toolkit. We'll build a "Company Assistant" using Google's Agent Development Kit (ADK) that can help employees find information, discover colleagues, and search company resources.
 
@@ -188,230 +554,6 @@ Once set up, your Company Assistant can handle requests like:
 
 This type of assistant can dramatically improve employee productivity by making company knowledge instantly accessible through natural conversation.
 
-## Available Tools
-
-| Tool name                | Import name         | Description                                    |
-| ------------------------ | ------------------- | ---------------------------------------------- |
-| `glean_search`           | `search`            | Search internal documents and knowledge bases  |
-| `glean_chat`             | `glean_chat`        | Conversational Q&A with Glean Assistant        |
-| `glean_read_document`    | `read_document`     | Read full document content by ID or URL        |
-| `glean_web_search`       | `web_search`        | Search the public web for external information |
-| `glean_calendar_search`  | `calendar_search`   | Find meetings and calendar events              |
-| `glean_employee_search`  | `employee_search`   | Search employees by name, team, or department  |
-| `glean_code_search`      | `code_search`       | Search source code repositories                |
-| `glean_gmail_search`     | `gmail_search`      | Search Gmail messages and conversations        |
-| `glean_outlook_search`   | `outlook_search`    | Search Outlook mail and calendar items         |
-
-### Explicit imports
-
-```python
-from glean.agent_toolkit.tools import search, glean_chat, read_document
-from glean.agent_toolkit.tools import web_search, calendar_search
-from glean.agent_toolkit.tools import employee_search, code_search
-from glean.agent_toolkit.tools import gmail_search, outlook_search
-```
-
-### Adapter methods
-
-Each tool function exposes adapter methods for framework conversion:
-
-| Method                | Returns                          | Framework           |
-| --------------------- | -------------------------------- | ------------------- |
-| `.as_openai_tool()`   | `FunctionTool` or `dict`         | OpenAI Agents SDK   |
-| `.as_langchain_tool()` | `langchain_core.tools.StructuredTool` | LangChain / LangGraph |
-| `.as_crewai_tool()`   | `CrewAI BaseTool`                | CrewAI              |
-| `.as_adk_tool()`      | `google.adk FunctionTool`        | Google ADK          |
-
-You can also use `get_tools()` to get all tools adapted for a framework at once:
-
-```python
-from glean.agent_toolkit import get_tools
-
-langchain_tools = get_tools("langchain")
-openai_tools = get_tools("openai", include=["glean_search", "glean_chat"])
-```
-
-### Web Research with Context
-
-```python snippet=readme/snippet-09.py
-from glean.agent_toolkit.tools import web_search
-
-# External information gathering
-web_tool = web_search.as_langchain_tool()
-
-# Example queries:
-# "Latest industry trends in machine learning"
-# "Current market analysis for SaaS companies"
-# "Recent news about our competitors"
-```
-
-## Quick Start Examples
-
-### Using `search` with Different Frameworks
-
-#### OpenAI Agents SDK
-
-```python snippet=readme/snippet-03.py
-import os
-
-from agents import Agent, Runner
-
-from glean.agent_toolkit.tools import search
-
-# Ensure environment variables are set
-assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
-assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
-assert os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY must be set"
-
-# Create an agent with the Glean search tool
-agent = Agent(
-    name="KnowledgeAssistant",
-    instructions="""You help users find information from the company knowledge base using
-    Glean search.""",
-    tools=[search.as_openai_tool()],  # Convert to an Agents SDK FunctionTool
-)
-
-# Run a search query
-result = Runner.run_sync(agent, "Find our Q4 planning documents")
-print(f"Search results: {result.final_output}")
-```
-
-#### LangChain
-
-```python snippet=readme/snippet-04.py
-import os
-
-# NOTE: AgentExecutor requires the full `langchain` package (not just langchain-core).
-# Install with: pip install langchain
-from langchain.agents import AgentExecutor, create_react_agent
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
-
-from glean.agent_toolkit.tools import search
-
-# Ensure environment variables are set
-assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
-assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
-
-# Convert to LangChain tool format
-langchain_tool = search.as_langchain_tool()
-
-llm = ChatOpenAI(model="gpt-4", temperature=0)
-tools = [langchain_tool]
-
-prompt_template = """You are a helpful assistant with access to company knowledge.
-Use the search tool to find relevant information when users ask questions.
-
-Tools available:
-{tools}
-
-Use this format:
-Question: {input}
-Thought: I should search for information about this topic
-Action: {tool_names}
-Action Input: your search query
-Observation: the search results
-Thought: I can now provide a helpful response
-Final Answer: your response based on the search results
-
-Question: {input}
-{agent_scratchpad}"""
-
-prompt = ChatPromptTemplate.from_template(prompt_template)
-agent = create_react_agent(llm, tools, prompt)
-agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
-
-# Search for company information
-result = agent_executor.invoke({"input": "What is our vacation policy?"})
-print(result["output"])
-```
-
-#### CrewAI
-
-```python snippet=readme/snippet-05.py
-import os
-
-from crewai import Agent, Crew, Task
-
-from glean.agent_toolkit.tools import search
-
-# Ensure environment variables are set
-assert os.getenv("GLEAN_API_TOKEN"), "GLEAN_API_TOKEN must be set"
-assert os.getenv("GLEAN_SERVER_URL"), "GLEAN_SERVER_URL must be set"
-
-# Convert to CrewAI tool format
-crewai_tool = search.as_crewai_tool()
-
-# Create a research agent
-researcher = Agent(
-    role="Corporate Knowledge Researcher",
-    goal="Find and summarize relevant company information",
-    backstory="""You are an expert at navigating company knowledge bases to find accurate,
-    up-to-date information.""",
-    tools=[crewai_tool],
-    verbose=True,
-)
-
-# Create a research task
-research_task = Task(
-    description="""Find information about our company's remote work policy and summarize the key
-    points.""",
-    expected_output="""A clear summary of the remote work policy including eligibility,
-    expectations, and guidelines.""",
-    agent=researcher,
-)
-
-# Execute the research
-crew = Crew(agents=[researcher], tasks=[research_task])
-result = crew.kickoff()
-print(result)
-```
-
-### Real-World Use Cases
-
-#### Employee Directory Search
-
-```python snippet=readme/snippet-06.py
-from glean.agent_toolkit.tools import employee_search
-
-# Find engineering team members
-engineering_team = employee_search.as_langchain_tool()
-
-# Example usage in an agent:
-# "Who are the senior engineers in the backend team?"
-# "Find Sarah Johnson's contact information"
-# "List all product managers in the San Francisco office"
-```
-
-#### Code Discovery
-
-```python snippet=readme/snippet-07.py
-from glean.agent_toolkit.tools import code_search
-
-# Search company codebases
-code_tool = code_search.as_langchain_tool()
-
-# Example queries:
-# "Find authentication middleware implementations"
-# "Show me recent changes to the payment processing module"
-# "Locate configuration files for the staging environment"
-```
-
-#### Email and Calendar Integration
-
-```python snippet=readme/snippet-08.py
-from glean.agent_toolkit.tools import calendar_search, gmail_search
-
-# Search emails and meetings
-gmail_tool = gmail_search.as_langchain_tool()
-calendar_tool = calendar_search.as_langchain_tool()
-
-# Example queries:
-# "Find emails about the product launch from last month"
-# "Show me my meetings with the design team this week"
-# "Search for messages containing budget discussions"
-```
-
 ## Creating Custom Tools with `@tool_spec`
 
 Define your own tools that work across all supported frameworks:
@@ -457,6 +599,23 @@ langchain_weather = get_weather.as_langchain_tool()
 crewai_weather = get_weather.as_crewai_tool()
 ```
 
+Custom tools are not included in `get_tools()` output by default — opt in with `get_tools(framework, builtin=None)`, `builtin=False`, or `include=["get_current_weather"]`. `async def` implementations are supported too (see "Async custom tools" above).
+
+## Advanced: Client Lifecycle with `GleanContext`
+
+Most users never need `GleanContext` — environment variables or `configure()` cover the common cases. Reach for it when you need explicit control over the underlying HTTP client's lifecycle (e.g. deterministic cleanup in a service, or multiple Glean instances in one process):
+
+```python
+from glean.agent_toolkit import GleanContext
+from glean.agent_toolkit.tools import search
+
+with GleanContext(api_token="...", server_url="https://your-company-be.glean.com") as ctx:
+    result = search(ctx, query="quarterly results")
+# The underlying HTTP client is closed on exit.
+```
+
+`GleanContext` creates its `glean.api_client.Glean` client lazily, caches it, and shares it across tool calls; `close()` (or the context manager) releases the HTTP resources. Every tool function accepts an optional `GleanContext` as its first argument, and adapters bind it automatically so LLM frameworks never see it. Note that `ctx.get_client()` raises `ValueError` for missing/invalid configuration — only tool calls wrap errors into `ToolResult`s.
+
 ## Agent Skills
 
 The `skills/` directory contains [Agent Skills](https://agentskills.io) — structured instructions that teach AI coding agents how to use the Glean Agent Toolkit effectively. Skills are supported by Claude Code, Cursor, GitHub Copilot, VS Code, Gemini CLI, OpenAI Codex, Goose, Amp, Roo Code, Junie, and [many others](https://agentskills.io).
@@ -480,7 +639,7 @@ npx skills add https://github.com/gleanwork/glean-agent-toolkit/tree/main/skills
 
 | Skill | Description |
 | --- | --- |
-| `glean-agent-toolkit-guide` | How to use the SDK: `get_tools()`, `GleanContext`, adapters, error handling, async |
+| `glean-agent-toolkit-guide` | How to use the SDK: `get_tools()`, `configure()`, adapters, error handling, async |
 | `glean-agent-toolkit-builder` | How to create custom tools with `@tool_spec` |
 
 ## Contributing

--- a/skills/glean-agent-toolkit-builder/SKILL.md
+++ b/skills/glean-agent-toolkit-builder/SKILL.md
@@ -210,6 +210,8 @@ return make_ok({"documents": [...]})
 # → {"status": "ok", "result": {...}, "error": None, "error_type": None, "suggested_action": None}
 ```
 
+Note: when a tool that returns a `ToolResult` envelope is converted through a framework adapter (`get_tools()`, `.as_*_tool()`), the adapter unwraps the envelope before handing it to the framework — the raw `result` payload on success, or a compact `{"error", "error_type", "suggested_action"}` dict on failure. Direct Python callers always see the full envelope. Custom tools are also not returned by `get_tools()` by default; opt in with `builtin=False`, `builtin=None`, or `include=`.
+
 ### `make_error(message, error_type, suggested_action)` — Build an error ToolResult
 
 ```python

--- a/skills/glean-agent-toolkit-guide/SKILL.md
+++ b/skills/glean-agent-toolkit-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glean-agent-toolkit-guide
-description: "How to use the Glean Agent Toolkit SDK. Use when building agents that integrate Glean enterprise search via the glean-agent-toolkit Python package. Triggers on: 'glean-agent-toolkit', 'glean agent toolkit', 'GleanContext', 'get_tools', 'as_openai_tool', 'as_langchain_tool', 'as_crewai_tool', 'as_adk_tool', '@tool_spec'."
+description: "How to use the Glean Agent Toolkit SDK. Use when building agents that integrate Glean enterprise search via the glean-agent-toolkit Python package. Triggers on: 'glean-agent-toolkit', 'glean agent toolkit', 'GleanContext', 'configure', 'get_tools', 'as_openai_tool', 'as_langchain_tool', 'as_crewai_tool', 'as_adk_tool', '@tool_spec'."
 ---
 
 # Glean Agent Toolkit — Usage Guide
@@ -30,17 +30,19 @@ pip install "glean-agent-toolkit[all]"
 
 ## Quick Start with `get_tools()`
 
-`get_tools()` is the primary API. It returns all Glean tools converted to a specific framework's format.
+`get_tools()` is the primary API. It returns the nine built-in Glean tools converted to a specific framework's format.
 
 ```python
 from glean.agent_toolkit import get_tools
 
-# Get all tools for a framework
+# The built-in Glean tools for a framework
 tools = get_tools("openai")       # list of OpenAI FunctionTool objects
-tools = get_tools("langchain")    # list of LangChain Tool objects
+tools = get_tools("langchain")    # list of LangChain StructuredTool objects
 tools = get_tools("crewai")       # list of CrewAI BaseTool objects
 tools = get_tools("adk")          # list of Google ADK FunctionTool objects
 ```
+
+By default only the built-in `glean_*` tools are returned. Custom `@tool_spec` tools require explicit opt-in: `builtin=False` (custom only), `builtin=None` (everything), or list them in `include=`.
 
 ### Filtering tools
 
@@ -58,22 +60,30 @@ tools = get_tools("langchain", exclude=["glean_outlook_search"])
 tools = get_tools(
     "openai",
     api_token="your-glean-api-token",
-    server_url="https://your-company-be.glean.com",
+    server_url="https://your-company-be.glean.com",  # full URL incl. https://
 )
 ```
 
-Or pass a pre-configured client:
+`server_url` must include the `http(s)://` scheme; a bare hostname fails fast with a clear error.
+
+### `configure()` — process-wide defaults
 
 ```python
-from glean.agent_toolkit import GleanContext
+import glean.agent_toolkit
 
-ctx = GleanContext(api_token="...", server_url="...")
-tools = get_tools("openai", client=ctx.get_client())
+glean.agent_toolkit.configure(
+    api_token="your-glean-api-token",
+    server_url="https://your-company-be.glean.com",  # or instance="your-company"
+)
+
+tools = glean.agent_toolkit.get_tools("langchain")  # uses the configured defaults
 ```
 
-## `GleanContext` — Dependency Injection
+`configure()` sets a process default used whenever no explicit context/client/credentials are supplied (tools, adapters, and `get_tools()` all honor it, sharing one HTTP client). It is idempotent and overridable per call.
 
-`GleanContext` is the dependency injection object that provides Glean API client access to every tool. It is the first parameter of every tool function, but adapters bind it automatically so LLM frameworks never see it.
+## Advanced: `GleanContext` — Client Lifecycle
+
+`GleanContext` is the dependency injection object that provides Glean API client access to every tool. It is the first parameter of every tool function, but adapters bind it automatically so LLM frameworks never see it. Most users only need env vars or `configure()`; use `GleanContext` for explicit client lifecycle control (`close()`/context manager) or multiple Glean instances in one process.
 
 ```python
 from glean.agent_toolkit.context import GleanContext
@@ -103,7 +113,7 @@ All tools are registered under the `glean.agent_toolkit.tools` package. Each too
 | Tool name (`spec.name`)  | Import name         | Description                                    |
 | ------------------------ | ------------------- | ---------------------------------------------- |
 | `glean_search`           | `search`            | Search internal documents and knowledge bases  |
-| `glean_chat`             | `glean_chat`        | Conversational Q&A with Glean Assistant        |
+| `glean_chat`             | `chat`              | Conversational Q&A with Glean Assistant        |
 | `glean_read_document`    | `read_document`     | Read full document content by ID or URL        |
 | `glean_web_search`       | `web_search`        | Search the public web                          |
 | `glean_calendar_search`  | `calendar_search`   | Find meetings and calendar events              |
@@ -117,7 +127,7 @@ All tools are registered under the `glean.agent_toolkit.tools` package. Each too
 ```python
 from glean.agent_toolkit.tools import (
     search,
-    glean_chat,
+    chat,
     read_document,
     web_search,
     calendar_search,
@@ -127,6 +137,8 @@ from glean.agent_toolkit.tools import (
     outlook_search,
 )
 ```
+
+The old `glean_chat` import name still works but is deprecated (emits `DeprecationWarning`); the tool ID stays `glean_chat`.
 
 ## Per-Tool Direct Usage
 
@@ -155,9 +167,9 @@ crewai_tool   = search.as_crewai_tool()     # CrewAI BaseTool
 adk_tool      = search.as_adk_tool()        # Google ADK FunctionTool
 ```
 
-## Error Handling
+## Results and Error Handling
 
-Every tool returns a `ToolResult` TypedDict:
+Direct Python calls to a tool function return a `ToolResult` TypedDict, and never raise (missing credentials included):
 
 ```python
 from glean.agent_toolkit.tools._common import ToolResult
@@ -172,11 +184,14 @@ from glean.agent_toolkit.tools._common import ToolResult
 }
 ```
 
+Framework adapters (`get_tools()`, `.as_*_tool()`) unwrap this envelope before handing results to the framework: on success they deliver the raw `result` payload (JSON-serialized where the framework expects strings); on failure a compact `{"error", "error_type", "suggested_action"}` dict. Custom tools that return non-envelope values pass through unchanged.
+
 ### Error types
 
 | `error_type`   | Meaning                        | `suggested_action` |
 | -------------- | ------------------------------ | ------------------ |
-| `"auth"`       | 401/403 — bad or expired token | `"check_credentials"` |
+| `"auth"`       | 401/403, or missing API token/credentials | `"check_credentials"` |
+| `"config"`     | Invalid server URL, unreachable/unresolvable host | `"check_configuration"` |
 | `"validation"` | Bad input / ValueError         | `"rephrase_query"` |
 | `"api"`        | Generic API error              | `"retry"`          |
 | `"timeout"`    | Request timed out              | `"retry"`          |
@@ -253,23 +268,17 @@ root_agent = Agent(
 
 ## Async Support
 
-Every `ToolSpec` has an `async_function` that wraps the sync implementation via `asyncio.run_in_executor`. The `_common.py` module also provides `arun_tool` for async tool execution.
-
-```python
-from glean.agent_toolkit.tools._common import arun_tool
-
-# Async version of run_tool — same signature
-result = await arun_tool("Glean Search", parameters, client=client)
-```
+Built-in tools are natively async end to end: framework async invocation (`await tool.ainvoke(...)` in LangChain, `on_invoke_tool` in the OpenAI Agents SDK, `run_async` in ADK) flows through the Glean SDK's async HTTP client with no thread-pool round-trip.
 
 For direct async use of a tool spec:
 
 ```python
 from glean.agent_toolkit.tools import search
 
-spec = search.tool_spec
-result = await spec.async_function(ctx, query="roadmap")
+result = await search.tool_spec.async_function(query="roadmap")
 ```
+
+Custom `@tool_spec` tools may be `async def`; the coroutine becomes the native async path. Custom sync tools get an `asyncio.to_thread` async wrapper automatically. Caveat: calling an `async def` tool synchronously works outside an event loop (sync bridge via `asyncio.run`) but raises a clear `RuntimeError` inside a running event loop — use the async path there.
 
 ## Environment Variables
 

--- a/snippets/readme/snippet-11.py
+++ b/snippets/readme/snippet-11.py
@@ -1,0 +1,10 @@
+from glean.agent_toolkit import get_tools
+
+# The nine built-in Glean tools, converted to LangChain StructuredTools.
+# Credentials are read from GLEAN_API_TOKEN and GLEAN_SERVER_URL.
+tools = get_tools("langchain")
+
+# Bind them to any LangChain / LangGraph agent, e.g.:
+#   from langgraph.prebuilt import create_react_agent
+#   agent = create_react_agent(llm, tools)
+print([tool.name for tool in tools])

--- a/snippets/readme/snippet-12.py
+++ b/snippets/readme/snippet-12.py
@@ -1,0 +1,12 @@
+from agents import Agent, Runner
+
+from glean.agent_toolkit import get_tools
+
+agent = Agent(
+    name="KnowledgeAssistant",
+    instructions="Answer questions using Glean enterprise search.",
+    tools=get_tools("openai"),
+)
+
+result = Runner.run_sync(agent, "Find our Q4 planning documents")
+print(result.final_output)

--- a/snippets/readme/snippet-13.py
+++ b/snippets/readme/snippet-13.py
@@ -1,0 +1,8 @@
+import glean.agent_toolkit
+
+glean.agent_toolkit.configure(
+    api_token="your-api-token",
+    server_url="https://your-company-be.glean.com",  # or instance="your-company"
+)
+
+tools = glean.agent_toolkit.get_tools("langchain")

--- a/snippets/readme/snippet-14.py
+++ b/snippets/readme/snippet-14.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from glean.agent_toolkit import get_tools
+
+
+async def main() -> None:
+    """Run glean_search through LangChain's native async path."""
+    (search_tool,) = get_tools("langchain", include=["glean_search"])
+    output = await search_tool.ainvoke({"query": "quarterly results", "page_size": 5})
+    print(output)
+
+
+asyncio.run(main())

--- a/src/glean/agent_toolkit/__init__.py
+++ b/src/glean/agent_toolkit/__init__.py
@@ -11,7 +11,7 @@ import warnings
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-from glean.agent_toolkit.context import GleanContext
+from glean.agent_toolkit.context import GleanContext, configure, get_default_context
 from glean.agent_toolkit.decorators import tool_spec
 from glean.agent_toolkit.registry import Registry, get_registry
 from glean.agent_toolkit.spec import ToolSpec
@@ -21,6 +21,7 @@ from . import adapters
 __all__ = [
     "BUILTIN_TOOL_NAMES",
     "GleanContext",
+    "configure",
     "get_tools",
     "tool_spec",
     "get_registry",
@@ -66,7 +67,7 @@ def get_tools(
     *,
     include: list[str] | None = None,
     exclude: list[str] | None = None,
-    builtin: bool | None = None,
+    builtin: bool | None = True,
     client: Any | None = None,
     api_token: str | None = None,
     server_url: str | None = None,
@@ -74,24 +75,29 @@ def get_tools(
 ) -> list[Any]:
     """Return framework-adapted tools filtered by include/exclude.
 
-    The tool registry is **global**: by default this returns every tool
-    registered in the current process, which includes both the built-in
-    ``glean_*`` tools and any user-defined tools registered via
-    :func:`tool_spec`. Use *builtin* (or *include*/*exclude*) to scope
-    the result.
+    By default this returns exactly the built-in ``glean_*`` tools (see
+    :data:`BUILTIN_TOOL_NAMES`). Tools registered via :func:`tool_spec`
+    live in the same global registry but require explicit opt-in:
+    ``builtin=False`` for custom tools only, ``builtin=None`` for all
+    registered tools, or list them via *include*.
 
     Args:
         framework: One of ``"openai"``, ``"langchain"``, ``"crewai"``, ``"adk"``.
         include: If given, only return tools whose names are in this list.
         exclude: If given, skip tools whose names are in this list.
-        builtin: If ``True``, only return the built-in Glean tools (see
-            :data:`BUILTIN_TOOL_NAMES`). If ``False``, only return
-            user-registered tools. If ``None`` (default), return all
-            registered tools. Applied in addition to *include*/*exclude*.
+        builtin: If ``True`` (default), only return the built-in Glean
+            tools. If ``False``, only return user-registered tools. If
+            ``None``, return all registered tools. Applied in addition to
+            *exclude*; tools explicitly listed in *include* bypass this
+            filter.
         client: Pre-configured :class:`~glean.api_client.Glean` instance.
         api_token: Glean API token (falls back to ``GLEAN_API_TOKEN``).
         server_url: Glean server URL (falls back to ``GLEAN_SERVER_URL``).
         instance: Glean instance name (falls back to ``GLEAN_INSTANCE``).
+
+    When none of *client*/*api_token*/*server_url*/*instance* are given,
+    the process-default configuration set via :func:`configure` (or the
+    environment variables) is used.
 
     Returns:
         List of framework-specific tool objects.
@@ -107,7 +113,12 @@ def get_tools(
             f"Unknown framework {framework!r}. Choose from: {', '.join(sorted(_ADAPTER_CLASSES))}"
         )
 
-    ctx = GleanContext(client=client, api_token=api_token, server_url=server_url, instance=instance)
+    if client is None and api_token is None and server_url is None and instance is None:
+        ctx = get_default_context()
+    else:
+        ctx = GleanContext(
+            client=client, api_token=api_token, server_url=server_url, instance=instance
+        )
 
     adapter_path = _ADAPTER_CLASSES[framework]
     module_path, class_name = adapter_path.rsplit(".", 1)
@@ -126,10 +137,13 @@ def get_tools(
             continue
         if spec.name in exclude_set:
             continue
-        if builtin is True and spec.name not in BUILTIN_TOOL_NAMES:
-            continue
-        if builtin is False and spec.name in BUILTIN_TOOL_NAMES:
-            continue
+        # Explicitly included tools are opted in regardless of the builtin
+        # filter, so `include=["my_custom_tool"]` works with the default.
+        if include_set is None or spec.name not in include_set:
+            if builtin is True and spec.name not in BUILTIN_TOOL_NAMES:
+                continue
+            if builtin is False and spec.name in BUILTIN_TOOL_NAMES:
+                continue
 
         adapter = adapter_cls(spec, ctx)
         try:

--- a/src/glean/agent_toolkit/adapters/adk.py
+++ b/src/glean/agent_toolkit/adapters/adk.py
@@ -7,7 +7,7 @@ import types
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeAlias, Union, get_args, get_origin
 
-from glean.agent_toolkit.adapters.base import BaseAdapter
+from glean.agent_toolkit.adapters.base import BaseAdapter, unwrap_tool_result
 from glean.agent_toolkit.spec import ToolSpec
 
 if TYPE_CHECKING:
@@ -227,13 +227,13 @@ class ADKAdapter(BaseAdapter["AdkFunctionTool"]):
         if async_func is not None:
 
             async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                return await async_func(**_to_kwargs(args, kwargs))
+                return unwrap_tool_result(await async_func(**_to_kwargs(args, kwargs)))
 
             wrapper = _async_wrapper
         else:
 
             def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-                return sync_func(**_to_kwargs(args, kwargs))
+                return unwrap_tool_result(sync_func(**_to_kwargs(args, kwargs)))
 
             wrapper = _sync_wrapper
 

--- a/src/glean/agent_toolkit/adapters/base.py
+++ b/src/glean/agent_toolkit/adapters/base.py
@@ -14,6 +14,33 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+_TOOL_RESULT_KEYS = frozenset({"status", "result", "error", "error_type", "suggested_action"})
+
+
+def unwrap_tool_result(value: Any) -> Any:
+    """Unwrap a ``ToolResult`` envelope into the framework-facing payload.
+
+    Adapters deliver the raw ``result`` payload to the framework on
+    success, and a compact ``{"error", "error_type", "suggested_action"}``
+    dict on failure, instead of the full five-key envelope. Values that are
+    not a ``ToolResult`` envelope (e.g. returns from custom ``@tool_spec``
+    tools) pass through unchanged. Direct Python callers of the tool
+    functions still receive the full envelope.
+    """
+    if (
+        isinstance(value, dict)
+        and set(value) == _TOOL_RESULT_KEYS
+        and value.get("status") in ("ok", "error")
+    ):
+        if value["status"] == "ok":
+            return value["result"]
+        return {
+            "error": value["error"],
+            "error_type": value["error_type"],
+            "suggested_action": value["suggested_action"],
+        }
+    return value
+
 
 def get_field_type(schema: dict[str, Any], *, use_date_types: bool = False) -> Any:
     """Determine the Python type from a JSON schema property.

--- a/src/glean/agent_toolkit/adapters/crewai.py
+++ b/src/glean/agent_toolkit/adapters/crewai.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel
 
-from glean.agent_toolkit.adapters.base import BaseAdapter, get_field_type
+from glean.agent_toolkit.adapters.base import BaseAdapter, get_field_type, unwrap_tool_result
 from glean.agent_toolkit.spec import ToolSpec
 
 if TYPE_CHECKING:
@@ -109,7 +109,9 @@ class GleanCrewAITool(BaseTool):  # type: ignore[misc]
     def _run(self, **kwargs: Any) -> str:
         """Run the tool with the given arguments.
 
-        CrewAI expects string returns from tools.
+        CrewAI expects string returns from tools. ``ToolResult`` envelopes
+        are unwrapped to the raw ``result`` payload on success or a compact
+        error dict on failure; other return values pass through as-is.
 
         Args:
             **kwargs: The arguments to pass to the function
@@ -117,7 +119,7 @@ class GleanCrewAITool(BaseTool):  # type: ignore[misc]
         Returns:
             JSON-serialized string result
         """
-        result = self._function(**kwargs)
+        result = unwrap_tool_result(self._function(**kwargs))
         if isinstance(result, str):
             return result
         return json.dumps(result, default=str)

--- a/src/glean/agent_toolkit/adapters/langchain.py
+++ b/src/glean/agent_toolkit/adapters/langchain.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from pydantic import BaseModel
 
-from glean.agent_toolkit.adapters.base import BaseAdapter, get_field_type
+from glean.agent_toolkit.adapters.base import BaseAdapter, get_field_type, unwrap_tool_result
 from glean.agent_toolkit.spec import ToolSpec
 
 if TYPE_CHECKING:
@@ -95,10 +95,12 @@ class LangChainAdapter(BaseAdapter[LangChainToolType]):
         (the legacy single-input ``Tool`` rejects dict inputs with more
         than one key and calls its func positionally).
 
-        LangChain's tool contract expects string returns.  The wrapper
-        JSON-serializes whatever the underlying function produces.
-        When an async_function is available, passes it as ``coroutine``
-        so LangChain can ``await`` it natively.
+        LangChain's tool contract expects string returns. On a ``ToolResult``
+        envelope the wrapper delivers the raw ``result`` payload on success
+        (or a compact error dict on failure) and JSON-serializes it; other
+        return values are JSON-serialized as-is. When an async_function is
+        available, passes it as ``coroutine`` so LangChain can ``await`` it
+        natively.
 
         Returns:
             LangChain StructuredTool instance
@@ -111,13 +113,13 @@ class LangChainAdapter(BaseAdapter[LangChainToolType]):
                 async_func = functools.partial(async_func, self.ctx)
 
         def _string_wrapper(**kwargs: Any) -> str:
-            result = original_func(**kwargs)
+            result = unwrap_tool_result(original_func(**kwargs))
             if isinstance(result, str):
                 return result
             return json.dumps(result, default=str)
 
         async def _async_string_wrapper(**kwargs: Any) -> str:
-            result = await async_func(**kwargs)  # type: ignore[misc]
+            result = unwrap_tool_result(await async_func(**kwargs))  # type: ignore[misc]
             if isinstance(result, str):
                 return result
             return json.dumps(result, default=str)

--- a/src/glean/agent_toolkit/adapters/openai.py
+++ b/src/glean/agent_toolkit/adapters/openai.py
@@ -8,9 +8,9 @@ import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 
-from glean.agent_toolkit.adapters.base import BaseAdapter
+from glean.agent_toolkit.adapters.base import BaseAdapter, unwrap_tool_result
 from glean.agent_toolkit.spec import ToolSpec
-from glean.agent_toolkit.tools._common import _classify_error, make_error
+from glean.agent_toolkit.tools._common import _classify_error
 
 if TYPE_CHECKING:
     from glean.agent_toolkit.context import GleanContext
@@ -152,8 +152,11 @@ class OpenAIAdapter(BaseAdapter[OpenAIToolType]):
         async def on_invoke_tool(ctx: Any, input_str: str) -> str:
             """Function that invokes the tool with parameters.
 
-            The OpenAI Agents SDK expects string returns from tool invocations.
-            Uses the async wrapper when available, falling back to sync.
+            The OpenAI Agents SDK expects string returns from tool
+            invocations. ``ToolResult`` envelopes are unwrapped to the raw
+            ``result`` payload on success or a compact error dict on
+            failure; other return values pass through as-is. Uses the async
+            wrapper when available, falling back to sync.
             """
             try:
                 params = json.loads(input_str) if input_str else {}
@@ -161,12 +164,19 @@ class OpenAIAdapter(BaseAdapter[OpenAIToolType]):
                     result = await async_func(**params)
                 else:
                     result = sync_func(**params)
+                result = unwrap_tool_result(result)
                 if isinstance(result, str):
                     return result
                 return json.dumps(result, default=str)
             except Exception as e:
                 error_type, suggested_action = _classify_error(e)
-                return json.dumps(make_error(str(e), error_type, suggested_action))
+                return json.dumps(
+                    {
+                        "error": str(e),
+                        "error_type": error_type,
+                        "suggested_action": suggested_action,
+                    }
+                )
 
         params_json_schema_dict = (
             self.tool_spec.input_schema

--- a/src/glean/agent_toolkit/context.py
+++ b/src/glean/agent_toolkit/context.py
@@ -10,6 +10,47 @@ from glean.api_client import Glean
 from glean.api_client.utils import BackoffStrategy, RetryConfig
 
 
+class GleanConfigurationError(ValueError):
+    """The Glean client configuration is invalid (e.g. a malformed server URL).
+
+    Subclasses :class:`ValueError` so existing callers that catch
+    ``ValueError`` from :meth:`GleanContext.get_client` keep working.
+    """
+
+
+class GleanCredentialsError(GleanConfigurationError):
+    """Required Glean credentials (API token or server location) are missing."""
+
+
+_MISSING_TOKEN_MESSAGE = (
+    "Glean API token is not configured. Set the GLEAN_API_TOKEN environment "
+    "variable, or pass api_token=/client= to configure()/get_tools()/GleanContext."
+)
+
+_MISSING_SERVER_MESSAGE = (
+    "Glean server location is not configured: GLEAN_SERVER_URL or GLEAN_INSTANCE "
+    "environment variable is required. Set one of them, or pass "
+    "server_url=/instance=/client= to configure()/get_tools()/GleanContext."
+)
+
+
+def _validate_server_url(server_url: str) -> str:
+    """Fail fast on a server URL without an http(s) scheme.
+
+    A missing scheme used to surface only after the SDK burned its full
+    connection-retry budget (~60s by default). Validating up front turns
+    that hang into an immediate, actionable error.
+    """
+    if not server_url.lower().startswith(("http://", "https://")):
+        raise GleanConfigurationError(
+            f"Invalid Glean server_url {server_url!r}: it must include an "
+            "http:// or https:// scheme, e.g. 'https://your-company-be.glean.com'. "
+            "Set GLEAN_SERVER_URL to the full URL, or pass server_url= to "
+            "configure()/get_tools()/GleanContext (or use instance='your-company')."
+        )
+    return server_url
+
+
 def _parse_retry_env_float(name: str, default: float) -> float:
     value = os.getenv(name)
     if not value:
@@ -79,7 +120,12 @@ class GleanContext:
             api_token: Glean API token (falls back to ``GLEAN_API_TOKEN``).
             server_url: Glean server URL (falls back to ``GLEAN_SERVER_URL``).
             instance: Glean instance name (falls back to ``GLEAN_INSTANCE``).
+
+        Raises:
+            GleanConfigurationError: If *server_url* lacks an http(s) scheme.
         """
+        if server_url is not None:
+            _validate_server_url(server_url)
         self._client = client
         self._api_token = api_token
         self._server_url = server_url
@@ -91,6 +137,12 @@ class GleanContext:
 
         The client is created lazily on first use, cached, and reused
         for the lifetime of this context. Creation is thread-safe.
+
+        Raises:
+            GleanCredentialsError: If no API token or server location is
+                configured (also a ``ValueError``).
+            GleanConfigurationError: If the resolved server URL lacks an
+                http(s) scheme (also a ``ValueError``).
         """
         with self._lock:
             if self._client is not None:
@@ -106,9 +158,10 @@ class GleanContext:
                 instance = os.getenv("GLEAN_INSTANCE")
 
             if not api_token:
-                raise ValueError("GLEAN_API_TOKEN environment variable is required")
+                raise GleanCredentialsError(_MISSING_TOKEN_MESSAGE)
 
             if server_url:
+                _validate_server_url(server_url)
                 client = Glean(
                     api_token=api_token,
                     server_url=server_url,
@@ -125,9 +178,7 @@ class GleanContext:
                 self._client = client
                 return client
             else:
-                raise ValueError(
-                    "GLEAN_SERVER_URL or GLEAN_INSTANCE environment variable is required"
-                )
+                raise GleanCredentialsError(_MISSING_SERVER_MESSAGE)
 
     def close(self) -> None:
         """Close the underlying Glean client and release HTTP resources.
@@ -158,3 +209,56 @@ class GleanContext:
     ) -> None:
         """Exit the context manager, closing the underlying client."""
         self.close()
+
+
+_default_context: GleanContext | None = None
+_default_context_lock = threading.Lock()
+
+
+def configure(
+    *,
+    api_token: str | None = None,
+    server_url: str | None = None,
+    instance: str | None = None,
+    client: Glean | None = None,
+) -> None:
+    """Set process-wide default Glean configuration.
+
+    The configured defaults are used whenever a tool, adapter, or
+    :func:`~glean.agent_toolkit.get_tools` call is made without an explicit
+    context/client/credentials. Calling :func:`configure` again replaces the
+    previous defaults (idempotent), and explicit per-call arguments always
+    win over the configured defaults.
+
+    Args:
+        api_token: Glean API token (falls back to ``GLEAN_API_TOKEN``).
+        server_url: Full Glean server URL including the http(s) scheme,
+            e.g. ``https://your-company-be.glean.com`` (falls back to
+            ``GLEAN_SERVER_URL``).
+        instance: Glean instance name (falls back to ``GLEAN_INSTANCE``).
+        client: Pre-configured :class:`~glean.api_client.Glean` client.
+
+    Raises:
+        GleanConfigurationError: If *server_url* lacks an http(s) scheme.
+    """
+    global _default_context
+    ctx = GleanContext(
+        client=client,
+        api_token=api_token,
+        server_url=server_url,
+        instance=instance,
+    )
+    with _default_context_lock:
+        _default_context = ctx
+
+
+def get_default_context() -> GleanContext:
+    """Return the process-default context for calls without an explicit one.
+
+    When :func:`configure` has been called, its context (and cached client)
+    is shared. Otherwise a fresh environment-driven :class:`GleanContext` is
+    returned, preserving the pre-:func:`configure` behavior.
+    """
+    with _default_context_lock:
+        ctx = _default_context
+    return ctx if ctx is not None else GleanContext()

--- a/src/glean/agent_toolkit/decorators.py
+++ b/src/glean/agent_toolkit/decorators.py
@@ -244,7 +244,8 @@ class ToolSpecFunction(Protocol):
 
         Args:
             ctx: Optional context bound into tool invocations. When omitted,
-                configuration falls back to environment variables.
+                configuration falls back to ``configure()`` defaults or
+                environment variables.
 
         Returns:
             OpenAI tool specification
@@ -256,7 +257,8 @@ class ToolSpecFunction(Protocol):
 
         Args:
             ctx: Optional context bound into tool invocations. When omitted,
-                configuration falls back to environment variables.
+                configuration falls back to ``configure()`` defaults or
+                environment variables.
 
         Returns:
             Google ADK tool
@@ -268,7 +270,8 @@ class ToolSpecFunction(Protocol):
 
         Args:
             ctx: Optional context bound into tool invocations. When omitted,
-                configuration falls back to environment variables.
+                configuration falls back to ``configure()`` defaults or
+                environment variables.
 
         Returns:
             LangChain tool
@@ -280,7 +283,8 @@ class ToolSpecFunction(Protocol):
 
         Args:
             ctx: Optional context bound into tool invocations. When omitted,
-                configuration falls back to environment variables.
+                configuration falls back to ``configure()`` defaults or
+                environment variables.
 
         Returns:
             CrewAI tool

--- a/src/glean/agent_toolkit/tools/__init__.py
+++ b/src/glean/agent_toolkit/tools/__init__.py
@@ -6,7 +6,9 @@ Importing this package will load all available tools.
 
 from __future__ import annotations
 
+import warnings
 from importlib import import_module as _import_module
+from typing import Any
 
 _tool_modules: list[str] = [
     "search",
@@ -17,15 +19,15 @@ _tool_modules: list[str] = [
     "gmail_search",
     "outlook_search",
     "read_document",
-    "chat",
+    "_chat",
 ]
 
 for _mod in _tool_modules:
     _import_module(f"{__name__}.{_mod}")
 
+from ._chat import chat  # noqa: E402
 from ._common import ToolResult  # noqa: E402
 from .calendar_search import calendar_search  # noqa: E402
-from .chat import glean_chat  # noqa: E402
 from .code_search import code_search  # noqa: E402
 from .employee_search import employee_search  # noqa: E402
 from .gmail_search import gmail_search  # noqa: E402
@@ -44,5 +46,23 @@ __all__: list[str] = [
     "gmail_search",
     "outlook_search",
     "read_document",
-    "glean_chat",
+    "chat",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve deprecated attribute names (PEP 562).
+
+    ``glean_chat`` is a deprecated alias for :func:`chat`; the tool ID
+    remains ``"glean_chat"``.
+    """
+    if name == "glean_chat":
+        warnings.warn(
+            "'glean_chat' is deprecated; import 'chat' instead "
+            "(from glean.agent_toolkit.tools import chat). "
+            "The tool ID remains 'glean_chat'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return chat
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/glean/agent_toolkit/tools/_chat.py
+++ b/src/glean/agent_toolkit/tools/_chat.py
@@ -1,4 +1,8 @@
-"""Chat tool for conversational Q&A with Glean Assistant."""
+"""Chat tool for conversational Q&A with Glean Assistant.
+
+Lives in a private module (``_chat``) so that ``glean.agent_toolkit.tools.chat``
+resolves to the tool *callable* rather than being shadowed by a submodule.
+"""
 
 from __future__ import annotations
 
@@ -120,7 +124,7 @@ register_backend(
     ),
     output_model=ChatResult,
 )
-def glean_chat(
+def chat(
     ctx: GleanContext | None = None,
     *,
     message: Annotated[
@@ -140,11 +144,7 @@ def glean_chat(
         ctx: Optional Glean context for client injection.
         message: The question to ask Glean Assistant.
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_chat", {"message": message}, client=client)
+    return execute_tool("glean_chat", {"message": message}, ctx=ctx)
 
 
-glean_chat.native_async(make_async_tool("glean_chat"))
+chat.native_async(make_async_tool("glean_chat"))

--- a/src/glean/agent_toolkit/tools/_common.py
+++ b/src/glean/agent_toolkit/tools/_common.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel
 
 from glean.api_client import Glean, models
 
-ErrorType = Literal["auth", "validation", "api", "timeout", "not_found", "rate_limit"]
-SuggestedAction = Literal["retry", "check_credentials", "rephrase_query"]
+ErrorType = Literal["auth", "validation", "api", "timeout", "not_found", "rate_limit", "config"]
+SuggestedAction = Literal["retry", "check_credentials", "rephrase_query", "check_configuration"]
 
 
 class ToolResult(TypedDict):
@@ -72,6 +72,47 @@ def _is_timeout_exception(exc: Exception) -> bool:
     return isinstance(exc, httpx.TimeoutException)
 
 
+_CONNECTION_ERROR_MARKERS = (
+    "getaddrinfo",
+    "name or service not known",
+    "nodename nor servname",
+    "failed to resolve",
+    "temporary failure in name resolution",
+    "connection refused",
+    "all connection attempts failed",
+)
+
+CONNECTION_ERROR_HINT = (
+    " (could not connect to the Glean API: check that GLEAN_SERVER_URL/GLEAN_INSTANCE "
+    "or the configured server_url/instance points at your Glean backend, e.g. "
+    "https://your-company-be.glean.com; connection errors are retried for up to "
+    "GLEAN_RETRY_MAX_ELAPSED seconds, default 60, before giving up)"
+)
+"""Hint appended to connection-level errors so misconfiguration is actionable."""
+
+
+def _is_connection_exception(exc: Exception) -> bool:
+    """Whether *exc* is a connection/DNS-level failure (host unreachable).
+
+    These almost always mean the configured server URL/instance is wrong
+    (typo, missing scheme resolved elsewhere, unreachable host), so they are
+    classified as ``config`` rather than a retryable ``api`` error.
+    """
+    import socket
+
+    if isinstance(exc, ConnectionError | socket.gaierror):
+        return True
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx ships with the SDK
+        pass
+    else:
+        if isinstance(exc, httpx.ConnectError):
+            return True
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _CONNECTION_ERROR_MARKERS)
+
+
 def _classify_error(exc: Exception) -> tuple[ErrorType, SuggestedAction]:
     """Classify an exception into an error type and suggested action.
 
@@ -86,6 +127,17 @@ def _classify_error(exc: Exception) -> tuple[ErrorType, SuggestedAction]:
 
     if _is_timeout_exception(exc) or "timeout" in msg or "timed out" in msg:
         return "timeout", "retry"
+
+    from glean.agent_toolkit.context import GleanConfigurationError, GleanCredentialsError
+
+    if isinstance(exc, GleanCredentialsError):
+        return "auth", "check_credentials"
+
+    if isinstance(exc, GleanConfigurationError):
+        return "config", "check_configuration"
+
+    if _is_connection_exception(exc):
+        return "config", "check_configuration"
 
     if isinstance(exc, ValueError):
         return "validation", "rephrase_query"
@@ -131,6 +183,21 @@ def make_error(
     )
 
 
+def error_result_from_exception(exc: Exception) -> ToolResult:
+    """Classify *exc* and build the error ``ToolResult`` for it.
+
+    Connection-level failures get an actionable hint appended: they are
+    almost always a misconfigured server URL/instance, and the SDK retries
+    them for the full ``GLEAN_RETRY_MAX_ELAPSED`` budget (60s by default)
+    before surfacing the error, which is otherwise baffling to callers.
+    """
+    error_type, suggested_action = _classify_error(exc)
+    message = str(exc)
+    if error_type == "config" and _is_connection_exception(exc):
+        message += CONNECTION_ERROR_HINT
+    return make_error(message, error_type, suggested_action)
+
+
 def run_with_error_handling(fn: Any, *args: Any, **kwargs: Any) -> ToolResult:
     """Call *fn* and wrap the outcome in a ``ToolResult``.
 
@@ -141,8 +208,7 @@ def run_with_error_handling(fn: Any, *args: Any, **kwargs: Any) -> ToolResult:
         result = fn(*args, **kwargs)
         return make_ok(result)
     except Exception as e:
-        error_type, suggested_action = _classify_error(e)
-        return make_error(str(e), error_type, suggested_action)
+        return error_result_from_exception(e)
 
 
 def clean_query(query: str) -> str:
@@ -195,17 +261,16 @@ def run_tool(
     """
     try:
         if client is None:
-            from glean.agent_toolkit.context import GleanContext
+            from glean.agent_toolkit.context import get_default_context
 
-            client = GleanContext().get_client()
+            client = get_default_context().get_client()
 
         from glean.agent_toolkit.tools._transport import ToolsCallBackend
 
         backend = ToolsCallBackend(tool_display_name)
         return make_ok(backend.call_raw(client, parameters))
     except Exception as e:
-        error_type, suggested_action = _classify_error(e)
-        return make_error(str(e), error_type, suggested_action)
+        return error_result_from_exception(e)
 
 
 async def arun_tool(
@@ -230,17 +295,16 @@ async def arun_tool(
     """
     try:
         if client is None:
-            from glean.agent_toolkit.context import GleanContext
+            from glean.agent_toolkit.context import get_default_context
 
-            client = GleanContext().get_client()
+            client = get_default_context().get_client()
 
         from glean.agent_toolkit.tools._transport import ToolsCallBackend
 
         backend = ToolsCallBackend(tool_display_name)
         return make_ok(await backend.call_raw_async(client, parameters))
     except Exception as e:
-        error_type, suggested_action = _classify_error(e)
-        return make_error(str(e), error_type, suggested_action)
+        return error_result_from_exception(e)
 
 
 def serialize_tool_result(value: Any) -> Any:

--- a/src/glean/agent_toolkit/tools/_transport.py
+++ b/src/glean/agent_toolkit/tools/_transport.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from glean.agent_toolkit.tools._common import (
     ToolResult,
-    _classify_error,
+    error_result_from_exception,
     make_error,
     make_ok,
     serialize_tool_result,
@@ -229,18 +229,23 @@ def execute_tool(
     arguments: Mapping[str, Any],
     *,
     client: Glean | None = None,
+    ctx: GleanContext | None = None,
 ) -> ToolResult:
     """Execute the registered backend for *tool_name* and wrap the outcome.
 
     This is the single execution seam for all built-in tools: client
     resolution, backend dispatch, ``ToolResult`` wrapping, and error
-    classification happen here.
+    classification happen here. Client resolution runs *inside* the error
+    boundary, so missing or invalid credentials come back as a structured
+    error ``ToolResult`` instead of raising.
 
     Args:
         tool_name: The registered tool name (e.g. ``"glean_search"``).
         arguments: The tool's high-level arguments.
-        client: Optional pre-configured Glean client. When ``None``, a
-            default client is created via ``GleanContext``.
+        client: Optional pre-configured Glean client. Wins over *ctx*.
+        ctx: Optional :class:`GleanContext` to resolve the client from.
+            When both *client* and *ctx* are ``None``, the process-default
+            context (see :func:`glean.agent_toolkit.configure`) is used.
 
     Returns:
         Structured ``ToolResult`` with status, result/error, and
@@ -256,14 +261,11 @@ def execute_tool(
 
     try:
         if client is None:
-            from glean.agent_toolkit.context import GleanContext
-
-            client = GleanContext().get_client()
+            client = _resolve_client(ctx)
 
         return make_ok(backend.execute(client, arguments))
     except Exception as e:
-        error_type, suggested_action = _classify_error(e)
-        return make_error(str(e), error_type, suggested_action)
+        return error_result_from_exception(e)
 
 
 async def execute_tool_async(
@@ -271,6 +273,7 @@ async def execute_tool_async(
     arguments: Mapping[str, Any],
     *,
     client: Glean | None = None,
+    ctx: GleanContext | None = None,
 ) -> ToolResult:
     """Async twin of :func:`execute_tool`.
 
@@ -281,8 +284,10 @@ async def execute_tool_async(
     Args:
         tool_name: The registered tool name (e.g. ``"glean_search"``).
         arguments: The tool's high-level arguments.
-        client: Optional pre-configured Glean client. When ``None``, a
-            default client is created via ``GleanContext``.
+        client: Optional pre-configured Glean client. Wins over *ctx*.
+        ctx: Optional :class:`GleanContext` to resolve the client from.
+            When both *client* and *ctx* are ``None``, the process-default
+            context (see :func:`glean.agent_toolkit.configure`) is used.
 
     Returns:
         Structured ``ToolResult`` with status, result/error, and
@@ -298,14 +303,20 @@ async def execute_tool_async(
 
     try:
         if client is None:
-            from glean.agent_toolkit.context import GleanContext
-
-            client = GleanContext().get_client()
+            client = _resolve_client(ctx)
 
         return make_ok(await backend.execute_async(client, arguments))
     except Exception as e:
-        error_type, suggested_action = _classify_error(e)
-        return make_error(str(e), error_type, suggested_action)
+        return error_result_from_exception(e)
+
+
+def _resolve_client(ctx: GleanContext | None) -> Glean:
+    """Resolve the Glean client from *ctx* or the process-default context."""
+    if ctx is None:
+        from glean.agent_toolkit.context import get_default_context
+
+        ctx = get_default_context()
+    return ctx.get_client()
 
 
 def make_async_tool(
@@ -328,10 +339,7 @@ def make_async_tool(
     """
 
     async def _async_tool(ctx: GleanContext | None = None, **arguments: Any) -> ToolResult:
-        from glean.agent_toolkit.context import GleanContext
-
-        ctx = ctx or GleanContext()
-        return await execute_tool_async(tool_name, arguments, client=ctx.get_client())
+        return await execute_tool_async(tool_name, arguments, ctx=ctx)
 
     _async_tool.__name__ = f"{tool_name}_async"
     _async_tool.__qualname__ = f"{tool_name}_async"

--- a/src/glean/agent_toolkit/tools/calendar_search.py
+++ b/src/glean/agent_toolkit/tools/calendar_search.py
@@ -60,11 +60,7 @@ def calendar_search(
         ctx: Optional Glean context for client injection.
         query: Calendar search query with optional filters - API will validate filter syntax
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_calendar_search", {"query": query}, client=client)
+    return execute_tool("glean_calendar_search", {"query": query}, ctx=ctx)
 
 
 calendar_search.native_async(make_async_tool("glean_calendar_search"))

--- a/src/glean/agent_toolkit/tools/code_search.py
+++ b/src/glean/agent_toolkit/tools/code_search.py
@@ -60,11 +60,7 @@ def code_search(
         ctx: Optional Glean context for client injection.
         query: Code search query with optional filters - API will validate filter syntax
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_code_search", {"query": query}, client=client)
+    return execute_tool("glean_code_search", {"query": query}, ctx=ctx)
 
 
 code_search.native_async(make_async_tool("glean_code_search"))

--- a/src/glean/agent_toolkit/tools/employee_search.py
+++ b/src/glean/agent_toolkit/tools/employee_search.py
@@ -61,11 +61,7 @@ def employee_search(
         query: Employee search query with optional filters
         like 'roletype:manager startafter:2023-01-01'
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_employee_search", {"query": query}, client=client)
+    return execute_tool("glean_employee_search", {"query": query}, ctx=ctx)
 
 
 employee_search.native_async(make_async_tool("glean_employee_search"))

--- a/src/glean/agent_toolkit/tools/gmail_search.py
+++ b/src/glean/agent_toolkit/tools/gmail_search.py
@@ -59,11 +59,7 @@ def gmail_search(
         ctx: Optional Glean context for client injection.
         query: Gmail search query with optional filters - API will validate filter syntax
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_gmail_search", {"query": query}, client=client)
+    return execute_tool("glean_gmail_search", {"query": query}, ctx=ctx)
 
 
 gmail_search.native_async(make_async_tool("glean_gmail_search"))

--- a/src/glean/agent_toolkit/tools/outlook_search.py
+++ b/src/glean/agent_toolkit/tools/outlook_search.py
@@ -59,11 +59,7 @@ def outlook_search(
         ctx: Optional Glean context for client injection.
         query: Outlook search query with optional filters - API will validate filter syntax
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_outlook_search", {"query": query}, client=client)
+    return execute_tool("glean_outlook_search", {"query": query}, ctx=ctx)
 
 
 outlook_search.native_async(make_async_tool("glean_outlook_search"))

--- a/src/glean/agent_toolkit/tools/read_document.py
+++ b/src/glean/agent_toolkit/tools/read_document.py
@@ -139,14 +139,10 @@ def read_document(
     if error is not None:
         return error
 
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
     return execute_tool(
         "glean_read_document",
         {"document_id": document_id, "url": url},
-        client=client,
+        ctx=ctx,
     )
 
 
@@ -162,11 +158,8 @@ async def _read_document_async(
     if error is not None:
         return error
 
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
     return await execute_tool_async(
         "glean_read_document",
         {"document_id": document_id, "url": url},
-        client=ctx.get_client(),
+        ctx=ctx,
     )

--- a/src/glean/agent_toolkit/tools/search.py
+++ b/src/glean/agent_toolkit/tools/search.py
@@ -220,10 +220,6 @@ def search(
         filters: Optional structured filters ``[{field, values, exclude?}]``.
         page_size: Number of results per page (default 10).
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
     return execute_tool(
         "glean_search",
         {
@@ -232,7 +228,7 @@ def search(
             "filters": filters,
             "page_size": page_size,
         },
-        client=client,
+        ctx=ctx,
     )
 
 

--- a/src/glean/agent_toolkit/tools/web_search.py
+++ b/src/glean/agent_toolkit/tools/web_search.py
@@ -58,11 +58,7 @@ def web_search(
         ctx: Optional Glean context for client injection.
         query: Web search query containing keywords to search for
     """
-    from glean.agent_toolkit.context import GleanContext
-
-    ctx = ctx or GleanContext()
-    client = ctx.get_client()
-    return execute_tool("glean_web_search", {"query": query}, client=client)
+    return execute_tool("glean_web_search", {"query": query}, ctx=ctx)
 
 
 web_search.native_async(make_async_tool("glean_web_search"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,15 @@ def mock_glean_env_vars() -> Generator[None, None, None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def reset_default_context() -> Generator[None, None, None]:
+    """Reset the process-default context set via configure() between tests."""
+    import glean.agent_toolkit.context as context_module
+
+    yield
+    context_module._default_context = None
+
+
 @pytest.fixture
 def no_thread_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fail the test if an async invocation round-trips through a thread.

--- a/tests/e2e/_live.py
+++ b/tests/e2e/_live.py
@@ -45,16 +45,36 @@ def unwrap_ok_or_skip(result: Any, tool_name: str) -> Any:
     - ``error_type`` in validation/not_found: SKIP with the server's reason
       (tool or feature not configured on this instance).
     - ``error_type == "rate_limit"``: SKIP (transient, not a regression).
-    - anything else (api/timeout): FAIL (real server or transport problem).
+    - anything else (api/timeout/config): FAIL (real server, transport, or
+      configuration problem).
     """
     assert_tool_result_envelope(result)
 
     if result["status"] == "ok":
         return result["result"]
 
-    error_type = result["error_type"]
-    error = result["error"]
+    _skip_or_fail_for_error(result["error_type"], result["error"], tool_name)
+    raise AssertionError("unreachable")  # pragma: no cover
 
+
+COMPACT_ERROR_KEYS = frozenset({"error", "error_type", "suggested_action"})
+
+
+def unwrap_adapter_payload_or_skip(payload: Any, tool_name: str) -> Any:
+    """Return a framework-path payload, or skip/fail on the compact error dict.
+
+    Framework adapters deliver the RAW result payload on success and a
+    compact ``{"error", "error_type", "suggested_action"}`` dict on failure
+    (the ``ToolResult`` envelope is unwrapped at the adapter layer). Apply
+    the same skip/fail policy as :func:`unwrap_ok_or_skip`.
+    """
+    if isinstance(payload, dict) and set(payload) == COMPACT_ERROR_KEYS:
+        _skip_or_fail_for_error(payload["error_type"], payload["error"], tool_name)
+    return payload
+
+
+def _skip_or_fail_for_error(error_type: Any, error: Any, tool_name: str) -> None:
+    """Shared skip/fail policy for live error classifications."""
     if error_type == "auth":
         pytest.fail(
             f"{tool_name}: authentication failure against live instance "

--- a/tests/e2e/test_frameworks_live.py
+++ b/tests/e2e/test_frameworks_live.py
@@ -1,8 +1,12 @@
 """Live framework-path e2e tests: glean_search through each real framework layer.
 
 Drives the converted glean_search tool through every supported framework's
-native invocation path against the live Glean API. No LLM API keys are
-required -- these invoke the tool layer directly through framework plumbing:
+native invocation path against the live Glean API and asserts the adapter
+result contract: the RAW result payload on success (the ToolResult envelope
+is unwrapped at the adapter layer), or a compact
+{"error", "error_type", "suggested_action"} dict on failure. No LLM API keys
+are required -- these invoke the tool layer directly through framework
+plumbing:
 
 - LangChain: ``tool.invoke`` and ``tool.ainvoke``
 - OpenAI Agents SDK: ``tool.on_invoke_tool``
@@ -19,7 +23,7 @@ from typing import Any
 import pytest
 
 from glean.agent_toolkit import get_tools
-from tests.e2e._live import unwrap_ok_or_skip
+from tests.e2e._live import unwrap_adapter_payload_or_skip
 
 try:
     from glean.agent_toolkit.adapters.langchain import HAS_LANGCHAIN
@@ -53,8 +57,9 @@ def _get_search_tool(framework: str) -> Any:
     return tools[0]
 
 
-def _assert_live_search_result(tool_result: Any, framework_path: str) -> None:
-    payload = unwrap_ok_or_skip(tool_result, f"glean_search via {framework_path}")
+def _assert_live_search_result(raw_payload: Any, framework_path: str) -> None:
+    """Assert the NEW adapter contract: the raw result payload, no envelope."""
+    payload = unwrap_adapter_payload_or_skip(raw_payload, f"glean_search via {framework_path}")
     assert isinstance(payload, dict)
     assert set(payload) == SEARCH_PAYLOAD_KEYS
     assert isinstance(payload["results"], list)

--- a/tests/e2e/test_tools_live.py
+++ b/tests/e2e/test_tools_live.py
@@ -14,9 +14,9 @@ import pytest
 
 from glean.agent_toolkit.tools import (
     calendar_search,
+    chat,
     code_search,
     employee_search,
-    glean_chat,
     gmail_search,
     outlook_search,
     read_document,
@@ -58,7 +58,7 @@ E2E_SENTINEL = "gat-e2e-ci"
 
 
 def test_chat_live() -> None:
-    result = glean_chat(message=f"{E2E_SENTINEL}: In one short sentence, what is Glean used for?")
+    result = chat(message=f"{E2E_SENTINEL}: In one short sentence, what is Glean used for?")
     payload = unwrap_ok_or_skip(result, "glean_chat")
 
     assert isinstance(payload, dict)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -164,11 +164,14 @@ async def test_read_document_as_adk_tool() -> None:
     assert list(inspect.signature(tool.func).parameters) == ["document_id", "url"]
 
     # Calling with neither document_id nor url short-circuits before any
-    # network access, exercising the real wrapper end-to-end.
+    # network access, exercising the real wrapper end-to-end. The adapter
+    # unwraps the ToolResult envelope into the compact error contract.
     result = await tool.func()
-    assert result["status"] == "error"
-    assert result["error_type"] == "validation"
-    assert result["error"] == "Provide exactly one of document_id or url"
+    assert result == {
+        "error": "Provide exactly one of document_id or url",
+        "error_type": "validation",
+        "suggested_action": "rephrase_query",
+    }
 
 
 def test_langchain_adapter_import_error() -> None:

--- a/tests/test_adk_invocation.py
+++ b/tests/test_adk_invocation.py
@@ -92,10 +92,17 @@ async def test_run_async_delivers_arguments_to_search() -> None:
         arguments: dict[str, Any],
         *,
         client: Any = None,
+        ctx: Any = None,
     ) -> dict[str, Any]:
         captured["tool_name"] = tool_name
         captured["arguments"] = dict(arguments)
-        return {"status": "success", "result": "canned-result"}
+        return {
+            "status": "ok",
+            "result": {"answer": "canned-result"},
+            "error": None,
+            "error_type": None,
+            "suggested_action": None,
+        }
 
     # ADK's run_async awaits the tool's native async path, which flows
     # through the transport seam's execute_tool_async.
@@ -106,7 +113,8 @@ async def test_run_async_delivers_arguments_to_search() -> None:
             tool_context=None,
         )
 
-    assert result == {"status": "success", "result": "canned-result"}
+    # The adapter unwraps the ToolResult envelope: raw payload only.
+    assert result == {"answer": "canned-result"}
     assert captured["tool_name"] == "glean_search"
     # Previously the (*args, **kwargs) wrapper signature made ADK drop every
     # argument, so the query never reached the tool implementation.

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -307,9 +307,9 @@ async def test_langchain_ainvoke_builtin_never_touches_to_thread(
     tool = web_search.as_langchain_tool()
     output = await tool.ainvoke({"query": "async native"})
 
+    # The adapter unwraps the ToolResult envelope: raw payload only.
     result = json.loads(output)
-    assert result["status"] == "ok"
-    assert result["result"]["rawResponse"] == {"results": [{"title": "hit"}]}
+    assert result["rawResponse"] == {"results": [{"title": "hit"}]}
 
 
 async def test_read_document_async_validates_arguments() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,6 +57,33 @@ class TestGleanContext:
             with pytest.raises(ValueError, match="GLEAN_SERVER_URL or GLEAN_INSTANCE"):
                 ctx.get_client()
 
+    def test_invalid_server_url_scheme_fails_fast_in_constructor(self) -> None:
+        from glean.agent_toolkit.context import GleanConfigurationError
+
+        with pytest.raises(GleanConfigurationError, match="http"):
+            GleanContext(api_token="tok", server_url="my-company-be.glean.com")
+
+    def test_invalid_server_url_scheme_from_env_fails_fast(self) -> None:
+        from glean.agent_toolkit.context import GleanConfigurationError
+
+        with patch.dict(os.environ, {
+            "GLEAN_API_TOKEN": "tok",
+            "GLEAN_SERVER_URL": "my-company-be.glean.com",
+        }, clear=True):
+            ctx = GleanContext()
+            with pytest.raises(GleanConfigurationError, match="https://your-company-be"):
+                ctx.get_client()
+
+    def test_missing_credential_errors_are_value_errors(self) -> None:
+        """The documented get_client() contract (raises ValueError) holds."""
+        from glean.agent_toolkit.context import (
+            GleanConfigurationError,
+            GleanCredentialsError,
+        )
+
+        assert issubclass(GleanCredentialsError, GleanConfigurationError)
+        assert issubclass(GleanConfigurationError, ValueError)
+
     def test_instance_fallback(self) -> None:
         with patch.dict(os.environ, {
             "GLEAN_API_TOKEN": "tok",
@@ -119,7 +146,8 @@ class TestRunTool:
         assert result["error_type"] == "api"
         assert result["suggested_action"] == "retry"
 
-    def test_run_tool_connection_error(self) -> None:
+    def test_run_tool_connection_error_is_config(self) -> None:
+        """Connection-level failures classify as config with an actionable hint."""
         parameters = {
             "query": models.ToolsCallParameter(name="query", value="test query")
         }
@@ -128,9 +156,10 @@ class TestRunTool:
         result = run_tool("Test Tool", parameters, client=client)
 
         assert result["status"] == "error"
-        assert result["error"] == "Network error"
-        assert result["error_type"] == "api"
-        assert result["suggested_action"] == "retry"
+        assert result["error"] is not None and result["error"].startswith("Network error")
+        assert "GLEAN_RETRY_MAX_ELAPSED" in result["error"]
+        assert result["error_type"] == "config"
+        assert result["suggested_action"] == "check_configuration"
 
     def test_run_tool_empty_parameters(self) -> None:
         mock_result = {"status": "success"}
@@ -169,8 +198,8 @@ class TestRunTool:
         assert result["error_type"] == "timeout"
         assert result["suggested_action"] == "retry"
 
-    def test_run_tool_client_creation_error(self) -> None:
-        """Test that run_tool without client falls back to GleanContext."""
+    def test_run_tool_missing_credentials_is_auth_error(self) -> None:
+        """Missing credentials come back as a structured auth error, not a raise."""
         parameters = {
             "query": models.ToolsCallParameter(name="query", value="test query")
         }
@@ -180,4 +209,6 @@ class TestRunTool:
 
         assert result["status"] == "error"
         assert result["error"] is not None and "GLEAN_API_TOKEN" in result["error"]
-        assert result["error_type"] == "validation"
+        assert "configure()" in result["error"]
+        assert result["error_type"] == "auth"
+        assert result["suggested_action"] == "check_credentials"

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,121 @@
+"""Tests for module-level configure() and the process-default context.
+
+configure() sets a process-wide default used whenever a tool, adapter, or
+get_tools() call is made without an explicit context/client/credentials.
+Explicit per-call arguments always win over the configured defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import glean.agent_toolkit.context as context_module
+from glean.agent_toolkit import configure, get_tools
+from glean.agent_toolkit.context import GleanContext, get_default_context
+from glean.agent_toolkit.tools._transport import execute_tool
+from glean.agent_toolkit.tools.search import search
+from glean.api_client import models
+
+
+def _mock_client(marker: str = "default") -> MagicMock:
+    client = MagicMock()
+    client.marker = marker
+    client.client.search.query.return_value = models.SearchResponse(results=[])
+    return client
+
+
+def test_configure_sets_default_context_used_by_tools() -> None:
+    client = _mock_client("configured")
+
+    configure(client=client)
+    result = search(query="hello")
+
+    assert result["status"] == "ok"
+    client.client.search.query.assert_called_once()
+
+
+def test_configure_default_used_by_execute_tool_seam() -> None:
+    client = _mock_client("configured")
+
+    configure(client=client)
+    result = execute_tool("glean_search", {"query": "hi"})
+
+    assert result["status"] == "ok"
+    client.client.search.query.assert_called_once()
+
+
+def test_explicit_ctx_overrides_configured_default() -> None:
+    default_client = _mock_client("default")
+    explicit_client = _mock_client("explicit")
+
+    configure(client=default_client)
+    result = search(GleanContext(client=explicit_client), query="hello")
+
+    assert result["status"] == "ok"
+    explicit_client.client.search.query.assert_called_once()
+    default_client.client.search.query.assert_not_called()
+
+
+def test_configure_is_idempotent_and_replaceable() -> None:
+    first = _mock_client("first")
+    second = _mock_client("second")
+
+    configure(client=first)
+    configure(client=second)
+
+    assert get_default_context().get_client() is second
+
+
+def test_get_default_context_without_configure_is_env_driven() -> None:
+    """No configure() call keeps the fresh, env-driven per-call context."""
+    assert context_module._default_context is None
+
+    ctx_a = get_default_context()
+    ctx_b = get_default_context()
+
+    assert isinstance(ctx_a, GleanContext)
+    assert ctx_a is not ctx_b  # no hidden shared state without opt-in
+
+
+def test_get_tools_uses_configured_default() -> None:
+    client = _mock_client("configured")
+    configure(client=client)
+
+    tools = get_tools("langchain", include=["glean_search"])
+    assert len(tools) == 1
+
+    output = tools[0].invoke({"query": "via configure"})
+    assert isinstance(output, str)
+    client.client.search.query.assert_called_once()
+
+
+def test_get_tools_explicit_client_wins_over_configured_default() -> None:
+    default_client = _mock_client("default")
+    explicit_client = _mock_client("explicit")
+    configure(client=default_client)
+
+    tools = get_tools("langchain", include=["glean_search"], client=explicit_client)
+    tools[0].invoke({"query": "explicit wins"})
+
+    explicit_client.client.search.query.assert_called_once()
+    default_client.client.search.query.assert_not_called()
+
+
+def test_configure_validates_server_url_scheme() -> None:
+    import pytest
+
+    from glean.agent_toolkit.context import GleanConfigurationError
+
+    with pytest.raises(GleanConfigurationError, match="http"):
+        configure(server_url="your-company-be.glean.com")
+
+
+def test_configure_with_credentials_builds_matching_client() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("glean.agent_toolkit.context.Glean") as mock_glean:
+            configure(api_token="tok", server_url="https://configured-be.glean.com")
+            get_default_context().get_client()
+
+    assert mock_glean.call_args.kwargs["api_token"] == "tok"
+    assert mock_glean.call_args.kwargs["server_url"] == "https://configured-be.glean.com"

--- a/tests/test_crewai_invocation.py
+++ b/tests/test_crewai_invocation.py
@@ -89,7 +89,8 @@ def test_crewai_glean_search_run_with_mocked_glean_layer(
     assert calls[0]["name"] == "glean_search"
     assert calls[0]["arguments"]["query"] == "test"
 
-    assert json.loads(output) == canned
+    # The adapter unwraps the ToolResult envelope: raw payload only.
+    assert json.loads(output) == {"results": ["doc1"]}
 
 
 def test_crewai_custom_tool_run_returns_result() -> None:

--- a/tests/test_get_tools.py
+++ b/tests/test_get_tools.py
@@ -106,8 +106,8 @@ def test_get_tools_builtin_false_returns_only_user_tools() -> None:
     assert not names & set(BUILTIN_TOOL_NAMES)
 
 
-def test_get_tools_builtin_default_returns_all() -> None:
-    """Default (builtin=None) keeps the registry-global behavior."""
+def test_get_tools_default_returns_only_builtins() -> None:
+    """Default (builtin=True) returns exactly the 9 built-in Glean tools."""
     from glean.agent_toolkit import BUILTIN_TOOL_NAMES, tool_spec
 
     @tool_spec(name="user_defined_probe_tool_3", description="Yet another user tool")
@@ -116,8 +116,39 @@ def test_get_tools_builtin_default_returns_all() -> None:
 
     tools = get_tools("langchain", client=_mock_client())
     names = {t.name for t in tools}
+    assert names == set(BUILTIN_TOOL_NAMES)
+    assert "user_defined_probe_tool_3" not in names
+
+
+def test_get_tools_builtin_none_returns_all() -> None:
+    """builtin=None opts into the full global registry (built-in + custom)."""
+    from glean.agent_toolkit import BUILTIN_TOOL_NAMES, tool_spec
+
+    @tool_spec(name="user_defined_probe_tool_4", description="One more user tool")
+    def user_tool(ctx: GleanContext, text: str) -> str:
+        return text
+
+    tools = get_tools("langchain", builtin=None, client=_mock_client())
+    names = {t.name for t in tools}
     assert set(BUILTIN_TOOL_NAMES) <= names
-    assert "user_defined_probe_tool_3" in names
+    assert "user_defined_probe_tool_4" in names
+
+
+def test_get_tools_include_opts_custom_tool_past_builtin_default() -> None:
+    """include= is an explicit opt-in that bypasses the builtin filter."""
+    from glean.agent_toolkit import tool_spec
+
+    @tool_spec(name="user_defined_probe_tool_5", description="Included user tool")
+    def user_tool(ctx: GleanContext, text: str) -> str:
+        return text
+
+    tools = get_tools(
+        "langchain",
+        include=["user_defined_probe_tool_5", "glean_search"],
+        client=_mock_client(),
+    )
+    names = {t.name for t in tools}
+    assert names == {"user_defined_probe_tool_5", "glean_search"}
 
 
 def test_get_tools_uses_ctx_params() -> None:

--- a/tests/test_invocation_matrix.py
+++ b/tests/test_invocation_matrix.py
@@ -13,8 +13,10 @@ Each matrix cell asserts three contracts:
    ``tool.run`` for CrewAI).
 2. The caller's arguments arrive in the outbound HTTP request body,
    mapped to the correct wire format for the endpoint the tool hits.
-3. A structured ``ToolResult``-shaped payload comes back through the
-   framework layer with the response payload intact.
+3. The adapter delivers the RAW result payload to the framework (the
+   ``ToolResult`` envelope is unwrapped at the adapter layer; on error a
+   compact ``{"error", "error_type", "suggested_action"}`` dict comes
+   back instead).
 
 The per-fix regression tests (test_langchain_invocation.py and friends)
 mock at the ``run_tool`` seam; this matrix goes one layer deeper and
@@ -62,6 +64,7 @@ CHAT_URL = f"{BASE_URL}/rest/api/v1/chat"
 GET_DOCUMENTS_URL = f"{BASE_URL}/rest/api/v1/getdocuments"
 
 TOOL_RESULT_KEYS = {"status", "result", "error", "error_type", "suggested_action"}
+COMPACT_ERROR_KEYS = {"error", "error_type", "suggested_action"}
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +297,7 @@ class FrameworkDriver:
     """One column of the matrix: a framework plus its native invocation path."""
 
     framework: str
-    # (converted_tool, args) -> parsed ToolResult dict.
+    # (converted_tool, args) -> parsed framework-facing payload dict.
     invoke: Callable[[Any, dict[str, Any]], Awaitable[dict[str, Any]]]
     # Whether the driver exercises the tool's async path. Async cells also
     # assert the NATIVE async chain: asyncio.to_thread is poisoned, so any
@@ -391,15 +394,11 @@ async def test_invocation_matrix(
     tool = tools[0]
 
     # (a) Invocation succeeds through the framework's native path.
-    tool_result = await driver.invoke(tool, case.args)
+    payload = await driver.invoke(tool, case.args)
 
-    # (c) A structured ToolResult-shaped payload returns.
-    assert set(tool_result) == TOOL_RESULT_KEYS
-    assert tool_result["status"] == "ok", tool_result
-    assert tool_result["error"] is None
-    assert tool_result["error_type"] is None
-    assert tool_result["suggested_action"] is None
-    case.check_result(tool_result["result"])
+    # (c) The adapter delivers the RAW result payload, not the envelope.
+    assert set(payload) != TOOL_RESULT_KEYS, f"envelope leaked through adapter: {payload}"
+    case.check_result(payload)
 
     # (b) The invocation arguments arrived in the outbound HTTP request body.
     requests = httpx_mock.get_requests()
@@ -409,3 +408,27 @@ async def test_invocation_matrix(
     assert str(http_request.url) == case.url
     assert http_request.headers["authorization"].startswith("Bearer ")
     case.check_request(json.loads(http_request.content))
+
+
+@pytest.mark.parametrize("driver", FRAMEWORK_DRIVERS)
+async def test_invocation_matrix_error_contract(
+    driver: FrameworkDriver,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Tool failures surface as a compact error dict through every framework."""
+    httpx_mock.add_response(
+        method="POST",
+        url=SEARCH_URL,
+        status_code=401,
+        json={"error": "Invalid token"},
+    )
+
+    tools = get_tools(driver.framework, include=["glean_search"])
+    assert len(tools) == 1
+
+    payload = await driver.invoke(tools[0], {"query": "anything"})
+
+    assert set(payload) == COMPACT_ERROR_KEYS, payload
+    assert payload["error_type"] == "auth"
+    assert payload["suggested_action"] == "check_credentials"
+    assert payload["error"]

--- a/tests/test_langchain_invocation.py
+++ b/tests/test_langchain_invocation.py
@@ -11,6 +11,7 @@ langchain-core package, mocking the network at the Glean client layer.
 from __future__ import annotations
 
 import importlib
+import json
 from typing import Any
 
 import pytest
@@ -43,6 +44,7 @@ def patched_run_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         arguments: dict[str, Any],
         *,
         client: Any = None,
+        ctx: Any = None,
     ) -> ToolResult:
         captured["tool_name"] = tool_name
         captured["arguments"] = dict(arguments)
@@ -53,6 +55,7 @@ def patched_run_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         arguments: dict[str, Any],
         *,
         client: Any = None,
+        ctx: Any = None,
     ) -> ToolResult:
         return fake_execute_tool(tool_name, arguments, client=client)
 
@@ -80,7 +83,8 @@ def test_invoke_multi_arg_through_langchain(patched_run_tool: dict[str, Any]) ->
     result = tool.invoke({"query": "test", "page_size": 5})
 
     assert isinstance(result, str)
-    assert CANNED_PAYLOAD in result
+    # The adapter unwraps the ToolResult envelope: raw payload only.
+    assert json.loads(result) == {"marker": CANNED_PAYLOAD}
     assert patched_run_tool["tool_name"] == "glean_search"
     assert patched_run_tool["arguments"]["query"] == "test"
     assert patched_run_tool["arguments"]["page_size"] == 5
@@ -92,7 +96,7 @@ async def test_ainvoke_multi_arg_through_langchain(patched_run_tool: dict[str, A
     result = await tool.ainvoke({"query": "async test", "page_size": 5})
 
     assert isinstance(result, str)
-    assert CANNED_PAYLOAD in result
+    assert json.loads(result) == {"marker": CANNED_PAYLOAD}
     assert patched_run_tool["arguments"]["query"] == "async test"
     assert patched_run_tool["arguments"]["page_size"] == 5
 

--- a/tests/test_openai_invocation.py
+++ b/tests/test_openai_invocation.py
@@ -95,7 +95,9 @@ async def test_on_invoke_tool_framework_path(monkeypatch: pytest.MonkeyPatch) ->
     canned = make_ok({"documents": [{"title": "canned-doc"}]})
     captured: dict[str, Any] = {}
 
-    async def fake_execute_tool_async(tool_name: str, arguments: Any, *, client: Any = None) -> Any:
+    async def fake_execute_tool_async(
+        tool_name: str, arguments: Any, *, client: Any = None, ctx: Any = None
+    ) -> Any:
         captured["tool_name"] = tool_name
         captured["arguments"] = dict(arguments)
         return canned
@@ -114,9 +116,9 @@ async def test_on_invoke_tool_framework_path(monkeypatch: pytest.MonkeyPatch) ->
     ctx_stub = MagicMock()  # the adapter ignores the SDK run context
     result_str = await tool.on_invoke_tool(ctx_stub, '{"query": "test"}')
 
+    # The adapter unwraps the ToolResult envelope: raw payload only.
     result = json.loads(result_str)
-    assert result["status"] == "ok"
-    assert result["result"] == {"documents": [{"title": "canned-doc"}]}
+    assert result == {"documents": [{"title": "canned-doc"}]}
     assert captured["tool_name"] == "glean_search"
 
 

--- a/tests/test_transport_contracts.py
+++ b/tests/test_transport_contracts.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from pytest_httpx import HTTPXMock
 
-from glean.agent_toolkit.tools.chat import glean_chat
+from glean.agent_toolkit.tools import chat
 from glean.agent_toolkit.tools.read_document import read_document
 from glean.agent_toolkit.tools.search import search
 
@@ -207,7 +207,7 @@ def test_chat_deserializes_realistic_chat_response(httpx_mock: HTTPXMock) -> Non
     """Fragments and citations from a realistic /chat payload are extracted."""
     httpx_mock.add_response(method="POST", url=CHAT_URL, json=REALISTIC_CHAT_RESPONSE)
 
-    result = glean_chat(message="What is our parental leave policy?")
+    result = chat(message="What is our parental leave policy?")
 
     assert result["status"] == "ok"
     assert result["error"] is None
@@ -246,7 +246,7 @@ def test_chat_response_without_citations_yields_empty_sources(httpx_mock: HTTPXM
         },
     )
 
-    result = glean_chat(message="Something obscure")
+    result = chat(message="Something obscure")
 
     assert result["status"] == "ok"
     assert result["result"]["answer"] == "I could not find anything relevant."

--- a/tests/tools/test_chat.py
+++ b/tests/tools/test_chat.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from glean.agent_toolkit.context import GleanContext
-from glean.agent_toolkit.tools.chat import ChatResult, glean_chat
+from glean.agent_toolkit.tools._chat import ChatResult, chat
 from glean.api_client import models
 
 # Feature detection mirroring the version-tolerant extraction in chat.py:
@@ -96,7 +96,7 @@ def _make_ctx(
 def test_glean_chat_success() -> None:
     ctx = _make_ctx()
 
-    result = glean_chat(ctx, message="What is our vacation policy?")
+    result = chat(ctx, message="What is our vacation policy?")
 
     assert result["status"] == "ok"
     assert result["error"] is None
@@ -109,7 +109,7 @@ def test_glean_chat_success() -> None:
 def test_glean_chat_api_error() -> None:
     ctx = _make_ctx(chat_side_effect=Exception("Chat API Error"))
 
-    result = glean_chat(ctx, message="anything")
+    result = chat(ctx, message="anything")
 
     assert result["status"] == "error"
     assert result["error"] == "Chat API Error"
@@ -130,7 +130,7 @@ def test_glean_chat_deduplicates_sources() -> None:
     )
     ctx = _make_ctx(chat_return=response)
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert len(result["result"]["sources"]) == 1
@@ -140,7 +140,7 @@ def test_glean_chat_empty_response() -> None:
     response = SimpleNamespace(messages=[])
     ctx = _make_ctx(chat_return=response)
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert result["result"]["answer"] == ""
@@ -157,7 +157,7 @@ def test_glean_chat_extracts_fragments() -> None:
     response = SimpleNamespace(messages=[msg])
     ctx = _make_ctx(chat_return=response)
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert "fragment text" in result["result"]["answer"]
@@ -175,7 +175,7 @@ def test_glean_chat_fragment_level_citations() -> None:
     msg = _make_fragment_citation_message("fragment answer", urls)
     ctx = _make_ctx(chat_return=SimpleNamespace(messages=[msg]))
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert result["result"]["answer"] == "fragment answer"
@@ -188,7 +188,7 @@ def test_glean_chat_message_level_citations_legacy() -> None:
     msg = _make_message_citation_message("legacy answer", urls)
     ctx = _make_ctx(chat_return=SimpleNamespace(messages=[msg]))
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert result["result"]["answer"] == "legacy answer"
@@ -202,10 +202,10 @@ def test_citation_shapes_produce_identical_sources() -> None:
     new_msg = _make_fragment_citation_message("same answer", urls)
     old_msg = _make_message_citation_message("same answer", urls)
 
-    new_result = glean_chat(
+    new_result = chat(
         _make_ctx(chat_return=SimpleNamespace(messages=[new_msg])), message="q"
     )
-    old_result = glean_chat(
+    old_result = chat(
         _make_ctx(chat_return=SimpleNamespace(messages=[old_msg])), message="q"
     )
 
@@ -242,7 +242,38 @@ def test_glean_chat_prefers_fragment_citations_over_message_citations() -> None:
         )
     ctx = _make_ctx(chat_return=SimpleNamespace(messages=[msg]))
 
-    result = glean_chat(ctx, message="test")
+    result = chat(ctx, message="test")
 
     assert result["status"] == "ok"
     assert [s["url"] for s in result["result"]["sources"]] == [fragment_url]
+
+
+def test_chat_import_name_is_the_tool_callable() -> None:
+    """B2: `from glean.agent_toolkit.tools import chat` yields the tool."""
+    from glean.agent_toolkit.tools import chat as imported_chat
+
+    assert callable(imported_chat)
+    assert imported_chat.tool_spec.name == "glean_chat"
+
+
+def test_glean_chat_alias_emits_deprecation_warning() -> None:
+    """The legacy `glean_chat` import keeps working but warns."""
+    import warnings
+
+    import glean.agent_toolkit.tools as tools_pkg
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        alias = tools_pkg.glean_chat
+
+    assert alias is tools_pkg.chat
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_tools_package_unknown_attribute_raises() -> None:
+    import pytest
+
+    import glean.agent_toolkit.tools as tools_pkg
+
+    with pytest.raises(AttributeError):
+        tools_pkg.not_a_real_tool

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -122,8 +122,73 @@ def test_classify_error_validation() -> None:
     assert action == "rephrase_query"
 
 
-def test_classify_error_connection() -> None:
+def test_classify_error_connection_is_config() -> None:
     error_type, action = _classify_error(ConnectionError("DNS failure"))
+    assert error_type == "config"
+    assert action == "check_configuration"
+
+
+def test_classify_error_httpx_connect_error_is_config() -> None:
+    error_type, action = _classify_error(
+        httpx.ConnectError("[Errno 8] nodename nor servname provided, or not known")
+    )
+    assert error_type == "config"
+    assert action == "check_configuration"
+
+
+def test_classify_error_dns_gaierror_is_config() -> None:
+    import socket
+
+    error_type, action = _classify_error(
+        socket.gaierror(8, "nodename nor servname provided, or not known")
+    )
+    assert error_type == "config"
+    assert action == "check_configuration"
+
+
+def test_classify_error_credentials_is_auth() -> None:
+    from glean.agent_toolkit.context import GleanCredentialsError
+
+    error_type, action = _classify_error(GleanCredentialsError("no token"))
+    assert error_type == "auth"
+    assert action == "check_credentials"
+
+
+def test_classify_error_configuration_is_config() -> None:
+    from glean.agent_toolkit.context import GleanConfigurationError
+
+    error_type, action = _classify_error(GleanConfigurationError("bad server_url"))
+    assert error_type == "config"
+    assert action == "check_configuration"
+
+
+def test_error_result_from_exception_appends_connection_hint() -> None:
+    from glean.agent_toolkit.tools._common import (
+        CONNECTION_ERROR_HINT,
+        error_result_from_exception,
+    )
+
+    result = error_result_from_exception(httpx.ConnectError("Failed to resolve host"))
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "config"
+    assert result["suggested_action"] == "check_configuration"
+    assert result["error"] is not None and result["error"].endswith(CONNECTION_ERROR_HINT)
+
+
+def test_error_result_from_exception_no_hint_for_non_connection_config() -> None:
+    from glean.agent_toolkit.context import GleanConfigurationError
+    from glean.agent_toolkit.tools._common import error_result_from_exception
+
+    result = error_result_from_exception(GleanConfigurationError("Invalid server_url"))
+
+    assert result["error"] == "Invalid server_url"
+    assert result["error_type"] == "config"
+
+
+def test_classify_error_read_error_stays_api() -> None:
+    """Mid-request network blips are transient: still api/retry."""
+    error_type, action = _classify_error(httpx.ReadError("read failed"))
     assert error_type == "api"
     assert action == "retry"
 

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -204,3 +204,37 @@ def test_shape_search_response_handles_empty_response() -> None:
     shaped = _shape_search_response(models.SearchResponse())
 
     assert shaped == {"results": [], "result_count": 0, "has_more_results": False}
+
+
+def test_search_missing_credentials_returns_tool_result_not_raise() -> None:
+    """A2: credential errors surface as a structured ToolResult, never raise."""
+    import os
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = search(query="anything")
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "auth"
+    assert result["suggested_action"] == "check_credentials"
+    assert result["error"] is not None
+    assert "GLEAN_API_TOKEN" in result["error"]
+    assert "configure()" in result["error"]
+
+
+def test_search_invalid_server_url_returns_config_error() -> None:
+    """A1: a scheme-less server URL fails fast with a config classification."""
+    import os
+    from unittest.mock import patch
+
+    with patch.dict(
+        os.environ,
+        {"GLEAN_API_TOKEN": "tok", "GLEAN_SERVER_URL": "my-company-be.glean.com"},
+        clear=True,
+    ):
+        result = search(query="anything")
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "config"
+    assert result["suggested_action"] == "check_configuration"
+    assert result["error"] is not None and "http" in result["error"]


### PR DESCRIPTION
## Summary

Implements the approved DX overhaul from the audit: non-breaking fixes A1/A2/A5 plus approved breaking changes B1–B4, with a single README/docs pass covering everything (including native async).

> **Breaking changes ahead** (adapter payloads, `get_tools()` default, `chat` import). No `!`/`BREAKING CHANGE:` footer is used on purpose (commitizen would bump 1.0.0); **release this as 0.8.0**.

## Non-breaking fixes

### A1 — Kill the 60s misconfig hang
- `GleanContext`/`configure()` now validate that `server_url` has an `http(s)://` scheme and fail fast with a clear message including an example (`https://your-company-be.glean.com`). Previously a bare hostname burned the full ~60s connection-retry budget.
- Connection/DNS failures (builtin `ConnectionError`, `socket.gaierror`, `httpx.ConnectError`, plus resolver-message heuristics) are classified as the **new `"config"` `ErrorType`** with the **new `"check_configuration"` suggested action** (Literal vocabularies in `_common.py` extended — pre-1.0, approved). Mid-request blips (`httpx.ReadError`, timeouts) still classify as `api`/`timeout` and stay retryable.
- The SDK's Speakeasy retry loop retries all `httpx.NetworkError`s when `retry_connection_errors=True` and exposes no hook to special-case NXDOMAIN, so per the approved fallback the error message now documents the retry budget: connection-level `config` errors carry a hint explaining the `GLEAN_RETRY_MAX_ELAPSED` budget (default 60s) and what to check.

### A2 — Credential errors return `ToolResult`, never raise
- Client resolution moved **inside** the transport seam's error boundary: `execute_tool`/`execute_tool_async` now accept `ctx=` and resolve the client (or the process-default context) within the `try`. All 9 tool modules pass `ctx` through instead of calling `ctx.get_client()` up front.
- Missing token/server now produce `make_error(..., "auth", "check_credentials")`; an invalid URL scheme produces `"config"`/`"check_configuration"`.
- Direct `GleanContext.get_client()` calls still raise (`GleanCredentialsError`/`GleanConfigurationError`, both `ValueError` subclasses — existing `except ValueError` code keeps working).

### A5 — Better credential message
`"...Set the GLEAN_API_TOKEN environment variable, or pass api_token=/client= to configure()/get_tools()/GleanContext."` (analogous message for the missing server URL/instance case).

## Breaking changes

### B1 — Adapters deliver raw results (envelope unwrapped)
| | Before | After |
|---|---|---|
| Framework tool success | JSON of `{"status":"ok","result":{...},"error":null,...}` | JSON of the raw `result` payload (`{...}`); plain object for ADK |
| Framework tool failure | 5-key envelope with `status:"error"` | compact `{"error", "error_type", "suggested_action"}` |
| Direct Python call | full `ToolResult` envelope | unchanged (full envelope) |

Applied uniformly in the langchain, openai, crewai, and adk adapters via a shared `unwrap_tool_result()` in `adapters/base.py`. Custom tools returning non-envelope values pass through unchanged. The invocation matrix asserts the new raw-result contract for every tool × framework cell, plus a new error-contract matrix over all framework drivers; `tests/e2e/test_frameworks_live.py` asserts the new adapter contract live.

### B2 — `chat` import name
| | Before | After |
|---|---|---|
| `from glean.agent_toolkit.tools import chat` | the `chat` **submodule** (shadowed the callable) | the **tool callable** |
| `from glean.agent_toolkit.tools import glean_chat` | the tool callable | deprecated alias (`DeprecationWarning` via module `__getattr__`) |
| `glean.agent_toolkit.tools.chat` submodule import | worked | module renamed to `_chat` (private) |

Tool ID stays `"glean_chat"`.

### B3 — `get_tools()` defaults to built-ins only
| | Before | After |
|---|---|---|
| `get_tools(framework)` | every registered tool (built-in + custom) | exactly the 9 built-in Glean tools (`builtin=True` default) |
| custom tools | included by default | opt-in: `builtin=False` (custom only), `builtin=None` (all), or `include=[...]` (explicitly included tools bypass the filter) |

### B4 — Module-level `configure()`
New `glean.agent_toolkit.configure(api_token=None, server_url=None, instance=None, client=None)` sets a process-default used whenever no ctx/client is supplied — tools, adapters, and `get_tools()` all honor it (sharing one cached client). Idempotent; explicit per-call arguments always win. Without `configure()` the previous env-driven per-call behavior is preserved. Exported from the package root.

## Docs
- README restructured: quickstart now leads with the one-call `get_tools()` bundle (LangChain + OpenAI Agents SDK) per audit A4; ADK company-assistant walkthrough moved later; new sections for `configure()`, the adapter result contract (raw/compact), the `config` error type, `server_url` format, native async (`await tool.ainvoke(...)`, `async def` custom tools incl. the sync-bridge `RuntimeError` caveat), and "Advanced: Client Lifecycle with `GleanContext`". Snippets synced (`mise run lint:readme` green).
- `skills/glean-agent-toolkit-guide` and `-builder` updated to the same contracts.

## Testing
- `mise run test`: **362 passed, 4 skipped** (framework-import skips only)
- Coverage: **94%** with `--cov-fail-under=90` (CI gate) passing; new behavior covered by new tests (`tests/test_configure.py`, config/credential classification, chat alias deprecation, adapter error contract matrix, A1/A2 tool-level tests)
- `mise run lint`: clean (ruff check/format, pyright 0 errors, README snippet check)
- e2e without creds: all 12 tests skip cleanly with the gate reason; `pyproject.toml`/`uv.lock`/workflows untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)